### PR TITLE
Leif/sync state

### DIFF
--- a/Sources/AppState/Application/Application+public.swift
+++ b/Sources/AppState/Application/Application+public.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public extension Application {
     // MARK: - Type Methods
 
@@ -50,6 +52,14 @@ public extension Application {
         to customApplication: CustomApplication.Type
     ) -> CustomApplication.Type {
         shared = customApplication.shared
+
+        NotificationCenter.default.removeObserver(shared)
+        NotificationCenter.default.addObserver(
+            shared,
+            selector: #selector(didChangeExternally),
+            name: NSUbiquitousKeyValueStore.didChangeExternallyNotification,
+            object: NSUbiquitousKeyValueStore.default
+        )
 
         return CustomApplication.self
     }

--- a/Sources/AppState/Application/Application+public.swift
+++ b/Sources/AppState/Application/Application+public.swift
@@ -51,9 +51,10 @@ public extension Application {
     static func promote<CustomApplication: Application>(
         to customApplication: CustomApplication.Type
     ) -> CustomApplication.Type {
+        NotificationCenter.default.removeObserver(shared)
+
         shared = customApplication.shared
 
-        NotificationCenter.default.removeObserver(shared)
         NotificationCenter.default.addObserver(
             shared,
             selector: #selector(didChangeExternally),

--- a/Sources/AppState/Application/Application+public.swift
+++ b/Sources/AppState/Application/Application+public.swift
@@ -53,7 +53,13 @@ public extension Application {
     ) -> CustomApplication.Type {
         NotificationCenter.default.removeObserver(shared)
 
+        let cache = shared.cache
         shared = customApplication
+
+        for (key, value) in cache.allValues {
+            shared.cache.set(value: value, forKey: key)
+            cache.remove(key)
+        }
 
         return CustomApplication.self
     }

--- a/Sources/AppState/Application/Application+public.swift
+++ b/Sources/AppState/Application/Application+public.swift
@@ -23,7 +23,7 @@ public extension Application {
      This static function promotes the shared singleton instance of the Application class to a custom Application type.
 
      - Parameters:
-        - customApplication: An instance of a custom Application subclass to be promoted to.
+        - customApplication: A custom Application subclass to be promoted to.
 
      - Returns: The type of the custom Application subclass.
 
@@ -42,19 +42,19 @@ public extension Application {
      To use the `promote` function to promote the shared singleton to `CustomApplication`:
 
      ```swift
-     Application.promote(to: CustomApplication())
+     Application.promote(to: CustomApplication.self)
      ```
 
      In this way, your custom Application subclass becomes the shared singleton instance, which you can then use throughout your application.
      */
     @discardableResult
     static func promote<CustomApplication: Application>(
-        to customApplication: CustomApplication
+        to customApplication: CustomApplication.Type
     ) -> CustomApplication.Type {
         NotificationCenter.default.removeObserver(shared)
 
         let cache = shared.cache
-        shared = customApplication
+        shared = customApplication.init()
 
         for (key, value) in cache.allValues {
             shared.cache.set(value: value, forKey: key)

--- a/Sources/AppState/Application/Application+public.swift
+++ b/Sources/AppState/Application/Application+public.swift
@@ -341,10 +341,10 @@ public extension Application {
 
         guard let value = cache.get(key, as: Value.self) else {
             let value = initial()
-            return State(initial: value, scope: scope)
+            return State(type: .state, initial: value, scope: scope)
         }
 
-        return State(initial: value, scope: scope)
+        return State(type: .state, initial: value, scope: scope)
     }
 
     /// Overloaded version of `state(initial:feature:id:)` function where id is generated from the code context.

--- a/Sources/AppState/Application/Application+public.swift
+++ b/Sources/AppState/Application/Application+public.swift
@@ -57,7 +57,7 @@ public extension Application {
 
         NotificationCenter.default.addObserver(
             shared,
-            selector: #selector(didChangeExternally),
+            selector: #selector(shared.didChangeExternally),
             name: NSUbiquitousKeyValueStore.didChangeExternallyNotification,
             object: NSUbiquitousKeyValueStore.default
         )

--- a/Sources/AppState/Application/Application+public.swift
+++ b/Sources/AppState/Application/Application+public.swift
@@ -160,8 +160,8 @@ public extension Application {
         }
     }
 
-    /// Removes the value from `UserDefaults` and resets the value to the inital value.
-    static func remove<Value>(
+    /// Resets the value to the inital value. If the inital value was `nil`, then the value will be removed from `UserDefaults`
+    static func reset<Value>(
         storedState keyPath: KeyPath<Application, StoredState<Value>>,
         _ fileID: StaticString = #fileID,
         _ function: StaticString = #function,
@@ -169,7 +169,7 @@ public extension Application {
         _ column: Int = #column
     ) {
         log(
-            debug: "💾 Removing StoredState \(String(describing: keyPath))",
+            debug: "💾 Resetting StoredState \(String(describing: keyPath))",
             fileID: fileID,
             function: function,
             line: line,
@@ -177,11 +177,29 @@ public extension Application {
         )
 
         var storedState = shared.value(keyPath: keyPath)
-        storedState.remove()
+        storedState.reset()
     }
 
-    /// Removes the value from `iCloud` and resets the value to the inital value.
+    /// Removes the value from `UserDefaults` and resets the value to the inital value.
+    @available(*, deprecated, renamed: "reset")
     static func remove<Value>(
+        storedState keyPath: KeyPath<Application, StoredState<Value>>,
+        _ fileID: StaticString = #fileID,
+        _ function: StaticString = #function,
+        _ line: Int = #line,
+        _ column: Int = #column
+    ) {
+        reset(
+            storedState: keyPath,
+            fileID,
+            function,
+            line,
+            column
+        )
+    }
+
+    /// Resets the value to the inital value. If the inital value was `nil`, then the value will be removed from `iClouds`
+    static func reset<Value>(
         syncState keyPath: KeyPath<Application, SyncState<Value>>,
         _ fileID: StaticString = #fileID,
         _ function: StaticString = #function,
@@ -189,7 +207,7 @@ public extension Application {
         _ column: Int = #column
     ) {
         log(
-            debug: "☁️ Removing SyncState \(String(describing: keyPath))",
+            debug: "☁️ Resetting SyncState \(String(describing: keyPath))",
             fileID: fileID,
             function: function,
             line: line,
@@ -197,7 +215,25 @@ public extension Application {
         )
 
         var syncState = shared.value(keyPath: keyPath)
-        syncState.remove()
+        syncState.reset()
+    }
+
+    /// Removes the value from `iCloud` and resets the value to the inital value.
+    @available(*, deprecated, renamed: "reset")
+    static func remove<Value>(
+        syncState keyPath: KeyPath<Application, SyncState<Value>>,
+        _ fileID: StaticString = #fileID,
+        _ function: StaticString = #function,
+        _ line: Int = #line,
+        _ column: Int = #column
+    ) {
+        reset(
+            syncState: keyPath,
+            fileID,
+            function,
+            line,
+            column
+        )
     }
 
     /**

--- a/Sources/AppState/Application/Application+public.swift
+++ b/Sources/AppState/Application/Application+public.swift
@@ -49,18 +49,11 @@ public extension Application {
      */
     @discardableResult
     static func promote<CustomApplication: Application>(
-        to customApplication: CustomApplication.Type
+        to customApplication: CustomApplication
     ) -> CustomApplication.Type {
         NotificationCenter.default.removeObserver(shared)
 
-        shared = customApplication.shared
-
-        NotificationCenter.default.addObserver(
-            shared,
-            selector: #selector(shared.didChangeExternally),
-            name: NSUbiquitousKeyValueStore.didChangeExternallyNotification,
-            object: NSUbiquitousKeyValueStore.default
-        )
+        shared = customApplication
 
         return CustomApplication.self
     }

--- a/Sources/AppState/Application/Application.swift
+++ b/Sources/AppState/Application/Application.swift
@@ -83,7 +83,7 @@ open class Application: NSObject, ObservableObject {
 
     deinit { bag.removeAll() }
 
-    public override init() {
+    public override required init() {
         lock = NSLock()
         bag = Set()
         cache = Cache()

--- a/Sources/AppState/Application/Application.swift
+++ b/Sources/AppState/Application/Application.swift
@@ -97,7 +97,7 @@ open class Application: NSObject, ObservableObject {
             self,
             selector: #selector(didChangeExternally),
             name: NSUbiquitousKeyValueStore.didChangeExternallyNotification,
-            object: nil
+            object: NSUbiquitousKeyValueStore.default
         )
     }
 

--- a/Sources/AppState/Application/Application.swift
+++ b/Sources/AppState/Application/Application.swift
@@ -37,7 +37,8 @@ open class Application: NSObject, ObservableObject {
         guard isLoggingEnabled else { return }
 
         let excludedFileIDs: [String] = [
-            "AppState/Application+StoredState.swift"
+            "AppState/Application+StoredState.swift",
+            "AppState/Application+SyncState.swift",
         ]
         let isFileIDValue: Bool = excludedFileIDs.contains(fileID.description) == false
 

--- a/Sources/AppState/Application/Application.swift
+++ b/Sources/AppState/Application/Application.swift
@@ -95,7 +95,7 @@ open class Application: NSObject, ObservableObject {
         consume(object: cache)
 
         NotificationCenter.default.addObserver(
-            Application.shared,
+            self,
             selector: #selector(didChangeExternally),
             name: NSUbiquitousKeyValueStore.didChangeExternallyNotification,
             object: NSUbiquitousKeyValueStore.default

--- a/Sources/AppState/Application/Application.swift
+++ b/Sources/AppState/Application/Application.swift
@@ -115,6 +115,8 @@ open class Application: NSObject, ObservableObject {
             line: #line,
             column: #column
         )
+
+        Application.dependency(\.icloudStore).synchronize()
     }
 
     /// Returns value for the provided keyPath. This method is thread safe

--- a/Sources/AppState/Application/Application.swift
+++ b/Sources/AppState/Application/Application.swift
@@ -103,7 +103,7 @@ open class Application: NSObject, ObservableObject {
     }
 
     @objc
-    func didChangeExternally(notification: Notification) {
+    open func didChangeExternally(notification: Notification) {
         Application.log(
             debug: """
                     ☁️ SyncState was changed externally {

--- a/Sources/AppState/Application/Application.swift
+++ b/Sources/AppState/Application/Application.swift
@@ -95,7 +95,7 @@ open class Application: NSObject, ObservableObject {
         consume(object: cache)
 
         NotificationCenter.default.addObserver(
-            self,
+            Application.shared,
             selector: #selector(didChangeExternally),
             name: NSUbiquitousKeyValueStore.didChangeExternallyNotification,
             object: NSUbiquitousKeyValueStore.default

--- a/Sources/AppState/Application/Types/Application+State.swift
+++ b/Sources/AppState/Application/Types/Application+State.swift
@@ -1,6 +1,14 @@
 extension Application {
     /// `State` encapsulates the value within the application's scope and allows any changes to be propagated throughout the scoped area.
     public struct State<Value>: CustomStringConvertible {
+        enum StateType {
+            case state
+            case stored
+            case sync
+        }
+
+        private let type: StateType
+
         /// A private backing storage for the value.
         private var _value: Value
 
@@ -20,6 +28,7 @@ extension Application {
                 _value = newValue
                 shared.cache.set(
                     value: Application.State(
+                        type: .state,
                         initial: newValue,
                         scope: scope
                     ),
@@ -39,15 +48,21 @@ extension Application {
              - scope: The scope in which the state exists
          */
         init(
+            type: StateType,
             initial value: Value,
             scope: Scope
         ) {
+            self.type = type
             self._value = value
             self.scope = scope
         }
 
         public var description: String {
-            "State<\(Value.self)>(\(value)) (\(scope.key))"
+            switch type {
+            case .state:    "State<\(Value.self)>(\(value)) (\(scope.key))"
+            case .stored:   "StoredState<\(Value.self)>(\(value)) (\(scope.key))"
+            case .sync:     "SyncState<\(Value.self)>(\(value)) (\(scope.key))"
+            }
         }
     }
 }

--- a/Sources/AppState/Application/Types/Application+StoredState.swift
+++ b/Sources/AppState/Application/Types/Application+StoredState.swift
@@ -71,10 +71,15 @@ extension Application {
             self.scope = scope
         }
 
-        /// Removes the value from `UserDefaults` and resets the value to the inital value.
-        public mutating func remove() {
+        /// Resets the value to the inital value. If the inital value was `nil`, then the value will be removed from `UserDefaults`
+        public mutating func reset() {
             value = initial()
-            userDefaults.removeObject(forKey: scope.key)
+        }
+
+        /// Resets the value to the inital value. If the inital value was `nil`, then the value will be removed from `UserDefaults`
+        @available(*, deprecated, renamed: "reset")
+        public mutating func remove() {
+            reset()
         }
     }
 }

--- a/Sources/AppState/Application/Types/Application+StoredState.swift
+++ b/Sources/AppState/Application/Types/Application+StoredState.swift
@@ -7,7 +7,7 @@ extension Application {
     }
 
     /// `StoredState` encapsulates the value within the application's scope and allows any changes to be propagated throughout the scoped area.  State is stored using `UserDefaults`.
-    public struct StoredState<Value>: CustomStringConvertible {
+    public struct StoredState<Value> {
         @AppDependency(\.userDefaults) private var userDefaults: UserDefaults
 
         /// The initial value of the state.
@@ -42,6 +42,7 @@ extension Application {
                 } else {
                     shared.cache.set(
                         value: Application.State(
+                            type: .stored,
                             initial: newValue,
                             scope: scope
                         ),
@@ -68,10 +69,6 @@ extension Application {
         ) {
             self.initial = initial
             self.scope = scope
-        }
-
-        public var description: String {
-            "StoredState<\(Value.self)>(\(value)) (\(scope.key))"
         }
 
         /// Removes the value from `UserDefaults` and resets the value to the inital value.

--- a/Sources/AppState/Application/Types/Application+SyncState.swift
+++ b/Sources/AppState/Application/Types/Application+SyncState.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+extension Application {
+    /// The default `NSUbiquitousKeyValueStore` instance.
+    public var icloudStore: Dependency<NSUbiquitousKeyValueStore> {
+        dependency(NSUbiquitousKeyValueStore.default)
+    }
+
+    /// The `SyncState` struct is a data structure designed to handle the state synchronization of an application that supports the `Codable` type.
+    /// It utilizes Apple's iCloud Key-Value Store to propagate state changes across multiple devices.
+    public struct SyncState<Value: Codable>: CustomStringConvertible {
+        @AppDependency(\.icloudStore) private var icloudStore: NSUbiquitousKeyValueStore
+
+        /// The initial value of the state.
+        private var initial: () -> Value
+
+        /// The current state value.
+        /// This value is retrieved from the iCloud Key-Value Store or the local cache.
+        /// If the value is not found in either, the initial value is returned.
+        /// When setting a new value, the value is saved to the iCloud Key-Value Store and the local cache.
+        public var value: Value {
+            get {
+                let cachedValue = shared.cache.get(
+                    scope.key,
+                    as: State<Value>.self
+                )
+
+                if let cachedValue = cachedValue {
+                    return cachedValue.value
+                }
+
+                guard
+                    let data = icloudStore.data(forKey: scope.key),
+                    let value = try? JSONDecoder().decode(Value.self, from: data)
+                else { return initial() }
+
+                return value
+            }
+            set {
+                let mirror = Mirror(reflecting: newValue)
+
+                if mirror.displayStyle == .optional,
+                   mirror.children.isEmpty {
+                    shared.cache.remove(scope.key)
+                    icloudStore.removeObject(forKey: scope.key)
+                    icloudStore.synchronize()
+                } else {
+                    shared.cache.set(
+                        value: Application.State(
+                            initial: newValue,
+                            scope: scope
+                        ),
+                        forKey: scope.key
+                    )
+
+                    do {
+                        let data = try JSONEncoder().encode(newValue)
+                        icloudStore.set(data, forKey: scope.key)
+                        icloudStore.synchronize()
+                    } catch {
+                        Application.log(
+                            error: error,
+                            message: "☁️ SyncState failed to encode: \(newValue)",
+                            fileID: #fileID,
+                            function: #function,
+                            line: #line,
+                            column: #column
+                        )
+                    }
+                }
+            }
+        }
+
+        /// The scope in which this state exists.
+        let scope: Scope
+
+        /**
+         Creates a new state within a given scope initialized with the provided value.
+
+         - Parameters:
+             - value: The initial value of the state
+             - scope: The scope in which the state exists
+         */
+        init(
+            initial: @escaping @autoclosure () -> Value,
+            scope: Scope
+        ) {
+            self.initial = initial
+            self.scope = scope
+        }
+
+        public var description: String {
+            "SyncState<\(Value.self)>(\(value)) (\(scope.key))"
+        }
+
+        /// Removes the value from `iCloud` and resets the value to the inital value.
+        public mutating func remove() {
+            value = initial()
+            icloudStore.removeObject(forKey: scope.key)
+            icloudStore.synchronize()
+        }
+    }
+}

--- a/Sources/AppState/Application/Types/Application+SyncState.swift
+++ b/Sources/AppState/Application/Types/Application+SyncState.swift
@@ -10,7 +10,17 @@ extension Application {
      The `SyncState` struct is a data structure designed to handle the state synchronization of an application that supports the `Codable` type.
      It utilizes Apple's iCloud Key-Value Store to propagate state changes across multiple devices.
 
+     Changes your app writes to the key-value store object are initially held in memory, then written to disk by the system at appropriate times. If you write to the key-value store object when the user is not signed into an iCloud account, the data is stored locally until the next synchronization opportunity. When the user signs into an iCloud account, the system automatically reconciles your local, on-disk keys and values with those on the iCloud server.
+
+     The total amount of space available in your app’s key-value store, for a given user, is 1 MB. There is a per-key value size limit of 1 MB, and a maximum of 1024 keys. If you attempt to write data that exceeds these quotas, the write attempt fails and no change is made to your iCloud key-value storage. In this scenario, the system posts the didChangeExternallyNotification notification with a change reason of NSUbiquitousKeyValueStoreQuotaViolationChange.
+
      - Note: The key-value store is intended for storing data that changes infrequently. As you test your devices, if the app on a device makes frequent changes to the key-value store, the system may defer the synchronization of some changes in order to minimize the number of round trips to the server. The more frequently the app make changes, the more likely the changes will be deferred and will not immediately show up on the other devices.
+
+     The maximum length for key strings for the iCloud key-value store is 64 bytes using UTF8 encoding. Attempting to write a value to a longer key name results in a runtime error.
+
+     To use this class, you must distribute your app through the App Store or Mac App Store, and you must request the com.apple.developer.ubiquity-kvstore-identifier entitlement in your Xcode project.
+
+     - Warning: Avoid using this class for data that is essential to your app’s behavior when offline; instead, store such data directly into the local user defaults database.
      */
     public struct SyncState<Value: Codable> {
         @AppDependency(\.icloudStore) private var icloudStore: NSUbiquitousKeyValueStore

--- a/Sources/AppState/Application/Types/Application+SyncState.swift
+++ b/Sources/AppState/Application/Types/Application+SyncState.swift
@@ -6,8 +6,12 @@ extension Application {
         dependency(NSUbiquitousKeyValueStore.default)
     }
 
-    /// The `SyncState` struct is a data structure designed to handle the state synchronization of an application that supports the `Codable` type.
-    /// It utilizes Apple's iCloud Key-Value Store to propagate state changes across multiple devices.
+    /**
+     The `SyncState` struct is a data structure designed to handle the state synchronization of an application that supports the `Codable` type.
+     It utilizes Apple's iCloud Key-Value Store to propagate state changes across multiple devices.
+
+     - Note: The key-value store is intended for storing data that changes infrequently. As you test your devices, if the app on a device makes frequent changes to the key-value store, the system may defer the synchronization of some changes in order to minimize the number of round trips to the server. The more frequently the app make changes, the more likely the changes will be deferred and will not immediately show up on the other devices.
+     */
     public struct SyncState<Value: Codable>: CustomStringConvertible {
         @AppDependency(\.icloudStore) private var icloudStore: NSUbiquitousKeyValueStore
 

--- a/Sources/AppState/Application/Types/Application+SyncState.swift
+++ b/Sources/AppState/Application/Types/Application+SyncState.swift
@@ -104,11 +104,15 @@ extension Application {
             self.scope = scope
         }
 
-        /// Removes the value from `iCloud` and resets the value to the inital value.
-        public mutating func remove() {
+        /// Resets the value to the inital value. If the inital value was `nil`, then the value will be removed from `iCloud`
+        public mutating func reset() {
             value = initial()
-            icloudStore.removeObject(forKey: scope.key)
-            icloudStore.synchronize()
+        }
+
+        /// Resets the value to the inital value. If the inital value was `nil`, then the value will be removed from `iCloud`
+        @available(*, deprecated, renamed: "reset")
+        public mutating func remove() {
+            reset()
         }
     }
 }

--- a/Sources/AppState/PropertyWrappers/AppState.swift
+++ b/Sources/AppState/PropertyWrappers/AppState.swift
@@ -27,7 +27,7 @@ import SwiftUI
         }
         nonmutating set {
             Application.log(
-                debug: "🔵 Setting State \(String(describing: keyPath)) = \(newValue)",
+                debug: "🔄 Setting State \(String(describing: keyPath)) = \(newValue)",
                 fileID: fileID,
                 function: function,
                 line: line,

--- a/Sources/AppState/PropertyWrappers/StoredState.swift
+++ b/Sources/AppState/PropertyWrappers/StoredState.swift
@@ -28,7 +28,7 @@ import SwiftUI
         }
         nonmutating set {
             Application.log(
-                debug: "🟣 Setting StoredState \(String(describing: keyPath)) = \(newValue)",
+                debug: "💾 Setting StoredState \(String(describing: keyPath)) = \(newValue)",
                 fileID: fileID,
                 function: function,
                 line: line,

--- a/Sources/AppState/PropertyWrappers/SyncState.swift
+++ b/Sources/AppState/PropertyWrappers/SyncState.swift
@@ -5,7 +5,17 @@ import SwiftUI
 /**
 `SyncState` is a property wrapper that allows SwiftUI views to subscribe to Application's state changes in a reactive way. The state is synchronized using `NSUbiquitousKeyValueStore`, and it works similarly to `State` and `Published`.
 
+ Changes your app writes to the key-value store object are initially held in memory, then written to disk by the system at appropriate times. If you write to the key-value store object when the user is not signed into an iCloud account, the data is stored locally until the next synchronization opportunity. When the user signs into an iCloud account, the system automatically reconciles your local, on-disk keys and values with those on the iCloud server.
+
+ The total amount of space available in your app’s key-value store, for a given user, is 1 MB. There is a per-key value size limit of 1 MB, and a maximum of 1024 keys. If you attempt to write data that exceeds these quotas, the write attempt fails and no change is made to your iCloud key-value storage. In this scenario, the system posts the didChangeExternallyNotification notification with a change reason of NSUbiquitousKeyValueStoreQuotaViolationChange.
+
  - Note: The key-value store is intended for storing data that changes infrequently. As you test your devices, if the app on a device makes frequent changes to the key-value store, the system may defer the synchronization of some changes in order to minimize the number of round trips to the server. The more frequently the app make changes, the more likely the changes will be deferred and will not immediately show up on the other devices.
+
+ The maximum length for key strings for the iCloud key-value store is 64 bytes using UTF8 encoding. Attempting to write a value to a longer key name results in a runtime error.
+
+ To use this class, you must distribute your app through the App Store or Mac App Store, and you must request the com.apple.developer.ubiquity-kvstore-identifier entitlement in your Xcode project.
+
+ - Warning: Avoid using this class for data that is essential to your app’s behavior when offline; instead, store such data directly into the local user defaults database.
  */
 @propertyWrapper public struct SyncState<Value: Codable>: DynamicProperty {
     /// Holds the singleton instance of `Application`.

--- a/Sources/AppState/PropertyWrappers/SyncState.swift
+++ b/Sources/AppState/PropertyWrappers/SyncState.swift
@@ -2,7 +2,11 @@ import Foundation
 import Combine
 import SwiftUI
 
-/// `SyncState` is a property wrapper that allows SwiftUI views to subscribe to Application's state changes in a reactive way. The state is synchronized using `NSUbiquitousKeyValueStore`, and it works similarly to `State` and `Published`.
+/**
+`SyncState` is a property wrapper that allows SwiftUI views to subscribe to Application's state changes in a reactive way. The state is synchronized using `NSUbiquitousKeyValueStore`, and it works similarly to `State` and `Published`.
+
+ - Note: The key-value store is intended for storing data that changes infrequently. As you test your devices, if the app on a device makes frequent changes to the key-value store, the system may defer the synchronization of some changes in order to minimize the number of round trips to the server. The more frequently the app make changes, the more likely the changes will be deferred and will not immediately show up on the other devices.
+ */
 @propertyWrapper public struct SyncState<Value: Codable>: DynamicProperty {
     /// Holds the singleton instance of `Application`.
     @ObservedObject private var app: Application = Application.shared

--- a/Sources/AppState/PropertyWrappers/SyncState.swift
+++ b/Sources/AppState/PropertyWrappers/SyncState.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Combine
+import SwiftUI
+
+/// `SyncState` is a property wrapper that allows SwiftUI views to subscribe to Application's state changes in a reactive way. The state is synchronized using `NSUbiquitousKeyValueStore`, and it works similarly to `State` and `Published`.
+@propertyWrapper public struct SyncState<Value: Codable>: DynamicProperty {
+    /// Holds the singleton instance of `Application`.
+    @ObservedObject private var app: Application = Application.shared
+
+    /// Path for accessing `SyncState` from Application.
+    private let keyPath: KeyPath<Application, Application.SyncState<Value>>
+
+    private let fileID: StaticString
+    private let function: StaticString
+    private let line: Int
+    private let column: Int
+
+    /// Represents the current value of the `SyncState`.
+    public var wrappedValue: Value {
+        get {
+            Application.syncState(
+                keyPath,
+                fileID,
+                function,
+                line,
+                column
+            ).value
+        }
+        nonmutating set {
+            Application.log(
+                debug: "☁️ Setting SyncState \(String(describing: keyPath)) = \(newValue)",
+                fileID: fileID,
+                function: function,
+                line: line,
+                column: column
+            )
+
+            var state = app.value(keyPath: keyPath)
+            state.value = newValue
+        }
+    }
+
+    /// A binding to the `State`'s value, which can be used with SwiftUI views.
+    public var projectedValue: Binding<Value> {
+        Binding(
+            get: { wrappedValue },
+            set: { wrappedValue = $0 }
+        )
+    }
+
+    /**
+     Initializes the AppState with a `keyPath` for accessing `SyncState` in Application.
+
+     - Parameter keyPath: The `KeyPath` for accessing `SyncState` in Application.
+     */
+    public init(
+        _ keyPath: KeyPath<Application, Application.SyncState<Value>>,
+        _ fileID: StaticString = #fileID,
+        _ function: StaticString = #function,
+        _ line: Int = #line,
+        _ column: Int = #column
+    ) {
+        self.keyPath = keyPath
+        self.fileID = fileID
+        self.function = function
+        self.line = line
+        self.column = column
+    }
+
+    /// A property wrapper's synthetic storage property. This is just for SwiftUI to mutate the `wrappedValue` and send event through `objectWillChange` publisher when the `wrappedValue` changes
+    public static subscript<OuterSelf: ObservableObject>(
+        _enclosingInstance observed: OuterSelf,
+        wrapped wrappedKeyPath: ReferenceWritableKeyPath<OuterSelf, Value>,
+        storage storageKeyPath: ReferenceWritableKeyPath<OuterSelf, Self>
+    ) -> Value {
+        get {
+            observed[keyPath: storageKeyPath].wrappedValue
+        }
+        set {
+            guard
+                let publisher = observed.objectWillChange as? ObservableObjectPublisher
+            else { return }
+
+            publisher.send()
+            observed[keyPath: storageKeyPath].wrappedValue = newValue
+        }
+    }
+}

--- a/Tests/AppStateTests/ApplicationTests.swift
+++ b/Tests/AppStateTests/ApplicationTests.swift
@@ -12,7 +12,7 @@ final class ApplicationTests: XCTestCase {
     func testCustomFunction() throws {
         let applicationType = Application.logging(isEnabled: true)
             .load(dependency: \.userDefaults)
-            .promote(to: SomeApplication.self)
+            .promote(to: SomeApplication())
 
         applicationType.someFunction()
     }

--- a/Tests/AppStateTests/ApplicationTests.swift
+++ b/Tests/AppStateTests/ApplicationTests.swift
@@ -12,7 +12,7 @@ final class ApplicationTests: XCTestCase {
     func testCustomFunction() throws {
         let applicationType = Application.logging(isEnabled: true)
             .load(dependency: \.userDefaults)
-            .promote(to: SomeApplication())
+            .promote(to: SomeApplication.self)
 
         applicationType.someFunction()
     }

--- a/Tests/AppStateTests/StoredStateTests.swift
+++ b/Tests/AppStateTests/StoredStateTests.swift
@@ -63,7 +63,7 @@ final class StoredStateTests: XCTestCase {
 
         XCTAssertEqual(viewModel.count, 27)
 
-        Application.remove(storedState: \.storedValue)
+        Application.reset(storedState: \.storedValue)
 
         XCTAssertNil(viewModel.count)
     }

--- a/Tests/AppStateTests/StoredStateTests.swift
+++ b/Tests/AppStateTests/StoredStateTests.swift
@@ -45,6 +45,8 @@ final class StoredStateTests: XCTestCase {
 
         XCTAssertEqual(storedValue.count, 1)
 
+        Application.logger.debug("StoredStateTests \(Application.description)")
+
         storedValue.count = nil
 
         XCTAssertNil(Application.storedState(\.storedValue).value)

--- a/Tests/AppStateTests/SyncStateTests.swift
+++ b/Tests/AppStateTests/SyncStateTests.swift
@@ -52,6 +52,8 @@ final class SyncStateTests: XCTestCase {
         syncValue.count = 1
 
         XCTAssertEqual(syncValue.count, 1)
+        
+        Application.logger.debug("SyncStateTests \(Application.description)")
 
         syncValue.count = nil
 

--- a/Tests/AppStateTests/SyncStateTests.swift
+++ b/Tests/AppStateTests/SyncStateTests.swift
@@ -83,7 +83,7 @@ final class SyncStateTests: XCTestCase {
 
         XCTAssertEqual(viewModel.count, 27)
 
-        Application.remove(syncState: \.syncValue)
+        Application.reset(syncState: \.syncValue)
 
         XCTAssertNil(viewModel.count)
     }

--- a/Tests/AppStateTests/SyncStateTests.swift
+++ b/Tests/AppStateTests/SyncStateTests.swift
@@ -1,0 +1,88 @@
+import SwiftUI
+import XCTest
+@testable import AppState
+
+fileprivate extension Application {
+    var syncValue: SyncState<Int?> {
+        syncState(id: "syncValue")
+    }
+    
+    var syncFailureValue: SyncState<Double> {
+        syncState(initial: -1, id: "syncValue")
+    }
+}
+
+fileprivate struct ExampleSyncValue {
+    @SyncState(\.syncValue) var count
+}
+
+fileprivate struct ExampleFailureSyncValue {
+    @SyncState(\.syncFailureValue) var count
+}
+
+fileprivate class ExampleStoringViewModel: ObservableObject {
+    @SyncState(\.syncValue) var count
+
+    func testPropertyWrapper() {
+        count = 27
+        _ = TextField(
+            value: $count,
+            format: .number,
+            label: { Text("Count") }
+        )
+    }
+}
+
+final class SyncStateTests: XCTestCase {
+    override class func setUp() {
+        Application.logging(isEnabled: true)
+    }
+
+    override class func tearDown() {
+        Application.logger.debug("SyncStateTests \(Application.description)")
+    }
+
+    func testSyncState() {
+        XCTAssertNil(Application.syncState(\.syncValue).value)
+
+        let syncValue = ExampleSyncValue()
+
+        XCTAssertEqual(syncValue.count, nil)
+
+        syncValue.count = 1
+
+        XCTAssertEqual(syncValue.count, 1)
+
+        syncValue.count = nil
+
+        XCTAssertNil(Application.syncState(\.syncValue).value)
+    }
+
+    func testFailEncodingSyncState() {
+        XCTAssertNotNil(Application.syncState(\.syncFailureValue).value)
+
+        let syncValue = ExampleFailureSyncValue()
+
+        XCTAssertEqual(syncValue.count, -1)
+
+        syncValue.count = Double.infinity
+
+        XCTAssertEqual(syncValue.count, Double.infinity)
+    }
+
+    func testStoringViewModel() {
+        XCTAssertNil(Application.syncState(\.syncValue).value)
+
+        let viewModel = ExampleStoringViewModel()
+
+        XCTAssertEqual(viewModel.count, nil)
+
+        viewModel.testPropertyWrapper()
+
+        XCTAssertEqual(viewModel.count, 27)
+
+        Application.remove(syncState: \.syncValue)
+
+        XCTAssertNil(viewModel.count)
+    }
+}


### PR DESCRIPTION
- https://developer.apple.com/documentation/foundation/nsubiquitouskeyvaluestore

> To configure your Xcode project first you need change the Bundle Identifiers for both macOS and iOS targets to match your own. Next, to work with iCloud and NSUbiquitousKeyValueStore, you need set up an iCloud key-value store ID for both targets. This sample already has the both targets’ iCloud capabilities set up, with the PrefsInCloud.entitlements file already created. You need to fill in your own key-value store IDs in those entitlement files to complete the configurations.
> 
> For each target (iOS and macOS):
> 
>     In the Xcode project, open the target’s PrefsInCloud.entitlements file.
> 
>     In that file, go to com.apple.developer.ubiquity-kvstore-identifier entitlement and replace $(CFBundleIdenfier) with your key-value store ID (i.e. $(TeamIdentifierPrefix)<your key-value_store ID>). For example if your key-value store ID is “com.mycompany.myKeyValueStoreID” it would look like this: $(TeamIdentifierPrefix)com.mycompany.myKeyValueStoreID. It’s important that the key-value store ID portions are the same between both targets.
> 
> In addition to configuring the project, you need to configure the devices in which the project runs.
> 
> To configure the iOS and macOS devices, verify that iCloud Drive is turned on. Then log into both devices with the same iCloud account.
> 
> source: https://developer.apple.com/documentation/foundation/icloud/synchronizing_app_preferences_with_icloud