### PR TITLE
Leif/update supported platforms

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,10 +5,10 @@ import PackageDescription
 let package = Package(
     name: "AppState",
     platforms: [
-        .iOS(.v16),
-        .watchOS(.v9),
-        .macOS(.v13),
-        .tvOS(.v16)
+        .iOS(.v15),
+        .watchOS(.v8),
+        .macOS(.v11),
+        .tvOS(.v15)
     ],
     products: [
         .library(

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ AppState is a Swift Package that simplifies the management of application state 
 
 - **StoredState:** Dedicated struct type for encapsulating and broadcasting stored value changes within the app's scope. Values are stored using `UserDefaults`.
 
-- **SyncState:** Dedicated struct type for encapsulating and broadcasting stored value changes within the app's scope. Values are stored using `iCloud`.
+- **SyncState:** Dedicated struct type for encapsulating and broadcasting stored value changes within the app's scope. Values are stored using `iCloud`. Requires iOS 15.0, watchOS 9.0, macOS 11.0, or tvOS 15.0.
 
 - **Dependency:** Dedicated struct type for encapsulating dependencies within the app's scope.
 
@@ -20,7 +20,7 @@ AppState is a Swift Package that simplifies the management of application state 
 
 - **StoredState (property wrapper):** A property wrapper that stores its values to `UserDefaults`. Works the same as `AppState` otherwise.
 
-- **SyncState (property wrapper):** A property wrapper that stores its values to `iCloud`. Works the same as `AppState` otherwise.
+- **SyncState (property wrapper):** A property wrapper that stores its values to `iCloud`. Works the same as `AppState` otherwise. Requires iOS 15.0, watchOS 9.0, macOS 11.0, or tvOS 15.0.
 
 - **AppDependency (property wrapper):** A property wrapper that simplifies the handling of dependencies throughout your application.
 
@@ -28,10 +28,10 @@ AppState is a Swift Package that simplifies the management of application state 
 
 - Swift 5.7 or later
 
-- iOS 16.0 or later
-- watchOS 9.0 or later
-- macOS 13.0 or later
-- tvOS 16.0 or later
+- iOS 15.0 or later
+- watchOS 8.0 or later
+- macOS 11.0 or later
+- tvOS 15.0 or later
 
 ## Getting Started
 

--- a/Sources/AppState/Application/Application+public.swift
+++ b/Sources/AppState/Application/Application+public.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-public extension Application {
-    // MARK: - Type Methods
+// MARK: - Application Functions
 
+public extension Application {
     /// Provides a description of the current application state
     static var description: String {
         let state = shared.cache.allValues
@@ -71,6 +71,18 @@ public extension Application {
         return CustomApplication.self
     }
 
+    /// Enables or disabled the default logging inside of Application.
+    @discardableResult
+    static func logging(isEnabled: Bool) -> Application.Type {
+        Application.isLoggingEnabled = isEnabled
+
+        return Application.self
+    }
+}
+
+// MARK: Dependency Functions
+
+public extension Application {
     /**
      Use this function to make sure Dependencies are intialized. If a Dependency is not loaded, it will be initialized whenever it is used next.
 
@@ -82,14 +94,6 @@ public extension Application {
         dependency keyPath: KeyPath<Application, Dependency<Value>>
     ) -> Application.Type {
         shared.load(dependency: keyPath)
-
-        return Application.self
-    }
-
-    /// Enables or disabled the default logging inside of Application.
-    @discardableResult
-    static func logging(isEnabled: Bool) -> Application.Type {
-        Application.isLoggingEnabled = isEnabled
 
         return Application.self
     }
@@ -167,162 +171,6 @@ public extension Application {
         }
     }
 
-    /// Resets the value to the inital value. If the inital value was `nil`, then the value will be removed from `UserDefaults`
-    static func reset<Value>(
-        storedState keyPath: KeyPath<Application, StoredState<Value>>,
-        _ fileID: StaticString = #fileID,
-        _ function: StaticString = #function,
-        _ line: Int = #line,
-        _ column: Int = #column
-    ) {
-        log(
-            debug: "💾 Resetting StoredState \(String(describing: keyPath))",
-            fileID: fileID,
-            function: function,
-            line: line,
-            column: column
-        )
-
-        var storedState = shared.value(keyPath: keyPath)
-        storedState.reset()
-    }
-
-    /// Removes the value from `UserDefaults` and resets the value to the inital value.
-    @available(*, deprecated, renamed: "reset")
-    static func remove<Value>(
-        storedState keyPath: KeyPath<Application, StoredState<Value>>,
-        _ fileID: StaticString = #fileID,
-        _ function: StaticString = #function,
-        _ line: Int = #line,
-        _ column: Int = #column
-    ) {
-        reset(
-            storedState: keyPath,
-            fileID,
-            function,
-            line,
-            column
-        )
-    }
-
-    /// Resets the value to the inital value. If the inital value was `nil`, then the value will be removed from `iClouds`
-    static func reset<Value>(
-        syncState keyPath: KeyPath<Application, SyncState<Value>>,
-        _ fileID: StaticString = #fileID,
-        _ function: StaticString = #function,
-        _ line: Int = #line,
-        _ column: Int = #column
-    ) {
-        log(
-            debug: "☁️ Resetting SyncState \(String(describing: keyPath))",
-            fileID: fileID,
-            function: function,
-            line: line,
-            column: column
-        )
-
-        var syncState = shared.value(keyPath: keyPath)
-        syncState.reset()
-    }
-
-    /// Removes the value from `iCloud` and resets the value to the inital value.
-    @available(*, deprecated, renamed: "reset")
-    static func remove<Value>(
-        syncState keyPath: KeyPath<Application, SyncState<Value>>,
-        _ fileID: StaticString = #fileID,
-        _ function: StaticString = #function,
-        _ line: Int = #line,
-        _ column: Int = #column
-    ) {
-        reset(
-            syncState: keyPath,
-            fileID,
-            function,
-            line,
-            column
-        )
-    }
-
-    /**
-     Retrieves a state from Application instance using the provided keypath.
-
-     - Parameter keyPath: KeyPath of the state value to be fetched
-     - Returns: The requested state of type `Value`.
-     */
-    static func state<Value>(
-        _ keyPath: KeyPath<Application, State<Value>>,
-        _ fileID: StaticString = #fileID,
-        _ function: StaticString = #function,
-        _ line: Int = #line,
-        _ column: Int = #column
-    ) -> State<Value> {
-        let appState = shared.value(keyPath: keyPath)
-
-        log(
-            debug: "🔄 Getting State \(String(describing: keyPath)) -> \(appState.value)",
-            fileID: fileID,
-            function: function,
-            line: line,
-            column: column
-        )
-
-        return appState
-    }
-
-    /**
-     Retrieves a stored state from Application instance using the provided keypath.
-
-     - Parameter keyPath: KeyPath of the state value to be fetched
-     - Returns: The requested state of type `Value`.
-     */
-    static func storedState<Value>(
-        _ keyPath: KeyPath<Application, StoredState<Value>>,
-        _ fileID: StaticString = #fileID,
-        _ function: StaticString = #function,
-        _ line: Int = #line,
-        _ column: Int = #column
-    ) -> StoredState<Value> {
-        let storedState = shared.value(keyPath: keyPath)
-
-        log(
-            debug: "💾 Getting StoredState \(String(describing: keyPath)) -> \(storedState.value)",
-            fileID: fileID,
-            function: function,
-            line: line,
-            column: column
-        )
-
-        return storedState
-    }
-
-    /**
-     Retrieves a state backed by iCloud from Application instance using the provided keypath.
-
-     - Parameter keyPath: KeyPath of the state value to be fetched
-     - Returns: The requested state of type `Value`.
-     */
-    static func syncState<Value: Codable>(
-        _ keyPath: KeyPath<Application, SyncState<Value>>,
-        _ fileID: StaticString = #fileID,
-        _ function: StaticString = #function,
-        _ line: Int = #line,
-        _ column: Int = #column
-    ) -> SyncState<Value> {
-        let storedState = shared.value(keyPath: keyPath)
-
-        log(
-            debug: "☁️ Getting SyncState \(String(describing: keyPath)) -> \(storedState.value)",
-            fileID: fileID,
-            function: function,
-            line: line,
-            column: column
-        )
-
-        return storedState
-    }
-
-    // MARK: - Instance Methods
-
     /**
      Retrieves a dependency for the provided `id`. If dependency is not present, it is created once using the provided closure.
 
@@ -374,6 +222,36 @@ public extension Application {
             )
         )
     }
+}
+
+// MARK: State Functions
+
+public extension Application {
+    /**
+     Retrieves a state from Application instance using the provided keypath.
+
+     - Parameter keyPath: KeyPath of the state value to be fetched
+     - Returns: The requested state of type `Value`.
+     */
+    static func state<Value>(
+        _ keyPath: KeyPath<Application, State<Value>>,
+        _ fileID: StaticString = #fileID,
+        _ function: StaticString = #function,
+        _ line: Int = #line,
+        _ column: Int = #column
+    ) -> State<Value> {
+        let appState = shared.value(keyPath: keyPath)
+
+        log(
+            debug: "🔄 Getting State \(String(describing: keyPath)) -> \(appState.value)",
+            fileID: fileID,
+            function: function,
+            line: line,
+            column: column
+        )
+
+        return appState
+    }
 
     /**
      Retrieves a state for the provided `id`. If the state is not present, it initializes a new state with the `initial` value.
@@ -418,6 +296,74 @@ public extension Application {
             )
         )
     }
+}
+
+// MARK: StoredState Functions
+
+public extension Application {
+    /// Resets the value to the inital value. If the inital value was `nil`, then the value will be removed from `UserDefaults`
+    static func reset<Value>(
+        storedState keyPath: KeyPath<Application, StoredState<Value>>,
+        _ fileID: StaticString = #fileID,
+        _ function: StaticString = #function,
+        _ line: Int = #line,
+        _ column: Int = #column
+    ) {
+        log(
+            debug: "💾 Resetting StoredState \(String(describing: keyPath))",
+            fileID: fileID,
+            function: function,
+            line: line,
+            column: column
+        )
+
+        var storedState = shared.value(keyPath: keyPath)
+        storedState.reset()
+    }
+
+    /// Removes the value from `UserDefaults` and resets the value to the inital value.
+    @available(*, deprecated, renamed: "reset")
+    static func remove<Value>(
+        storedState keyPath: KeyPath<Application, StoredState<Value>>,
+        _ fileID: StaticString = #fileID,
+        _ function: StaticString = #function,
+        _ line: Int = #line,
+        _ column: Int = #column
+    ) {
+        reset(
+            storedState: keyPath,
+            fileID,
+            function,
+            line,
+            column
+        )
+    }
+
+    /**
+     Retrieves a stored state from Application instance using the provided keypath.
+
+     - Parameter keyPath: KeyPath of the state value to be fetched
+     - Returns: The requested state of type `Value`.
+     */
+    static func storedState<Value>(
+        _ keyPath: KeyPath<Application, StoredState<Value>>,
+        _ fileID: StaticString = #fileID,
+        _ function: StaticString = #function,
+        _ line: Int = #line,
+        _ column: Int = #column
+    ) -> StoredState<Value> {
+        let storedState = shared.value(keyPath: keyPath)
+
+        log(
+            debug: "💾 Getting StoredState \(String(describing: keyPath)) -> \(storedState.value)",
+            fileID: fileID,
+            function: function,
+            line: line,
+            column: column
+        )
+
+        return storedState
+    }
 
     /**
      Retrieves a `UserDefaults` backed state for the provided `id`. If the state is not present, it initializes a new state with the `initial` value.
@@ -456,6 +402,75 @@ public extension Application {
             feature: feature,
             id: id
         )
+    }
+}
+
+// MARK: SyncState Functions
+
+@available(iOS 15.0, watchOS 9.0, macOS 11.0, tvOS 15.0, *)
+public extension Application {
+    /// Resets the value to the inital value. If the inital value was `nil`, then the value will be removed from `iClouds`
+    static func reset<Value>(
+        syncState keyPath: KeyPath<Application, SyncState<Value>>,
+        _ fileID: StaticString = #fileID,
+        _ function: StaticString = #function,
+        _ line: Int = #line,
+        _ column: Int = #column
+    ) {
+        log(
+            debug: "☁️ Resetting SyncState \(String(describing: keyPath))",
+            fileID: fileID,
+            function: function,
+            line: line,
+            column: column
+        )
+
+        var syncState = shared.value(keyPath: keyPath)
+        syncState.reset()
+    }
+
+    /// Removes the value from `iCloud` and resets the value to the inital value.
+    @available(*, deprecated, renamed: "reset")
+    static func remove<Value>(
+        syncState keyPath: KeyPath<Application, SyncState<Value>>,
+        _ fileID: StaticString = #fileID,
+        _ function: StaticString = #function,
+        _ line: Int = #line,
+        _ column: Int = #column
+    ) {
+        reset(
+            syncState: keyPath,
+            fileID,
+            function,
+            line,
+            column
+        )
+    }
+
+    /**
+     Retrieves a state backed by iCloud from Application instance using the provided keypath.
+
+     - Parameter keyPath: KeyPath of the state value to be fetched
+     - Returns: The requested state of type `Value`.
+     */
+    static func syncState<Value: Codable>(
+        _ keyPath: KeyPath<Application, SyncState<Value>>,
+        _ fileID: StaticString = #fileID,
+        _ function: StaticString = #function,
+        _ line: Int = #line,
+        _ column: Int = #column
+    ) -> SyncState<Value> {
+        let storedState = shared.value(keyPath: keyPath)
+
+        log(
+            debug: "☁️ Getting SyncState \(String(describing: keyPath)) -> \(storedState.value)",
+            fileID: fileID,
+            function: function,
+            line: line,
+            column: column
+        )
+
+        return storedState
     }
 
     /**

--- a/Sources/AppState/Application/Application.swift
+++ b/Sources/AppState/Application/Application.swift
@@ -94,15 +94,17 @@ open class Application: NSObject, ObservableObject {
 
         consume(object: cache)
 
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(didChangeExternally),
-            name: NSUbiquitousKeyValueStore.didChangeExternallyNotification,
-            object: NSUbiquitousKeyValueStore.default
-        )
+        if #available(iOS 15.0, watchOS 9.0, macOS 11.0, tvOS 15.0, *) {
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(didChangeExternally),
+                name: NSUbiquitousKeyValueStore.didChangeExternallyNotification,
+                object: NSUbiquitousKeyValueStore.default
+            )
+        }
     }
 
-    @objc
+    @objc @available(iOS 15.0, watchOS 9.0, macOS 11.0, tvOS 15.0, *)
     open func didChangeExternally(notification: Notification) {
         Application.log(
             debug: """

--- a/Sources/AppState/Application/Types/Application+SyncState.swift
+++ b/Sources/AppState/Application/Types/Application+SyncState.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+@available(iOS 15.0, watchOS 9.0, macOS 11.0, tvOS 15.0, *)
 extension Application {
     /// The default `NSUbiquitousKeyValueStore` instance.
     public var icloudStore: Dependency<NSUbiquitousKeyValueStore> {

--- a/Sources/AppState/PropertyWrappers/SyncState.swift
+++ b/Sources/AppState/PropertyWrappers/SyncState.swift
@@ -17,6 +17,7 @@ import SwiftUI
 
  - Warning: Avoid using this class for data that is essential to your app’s behavior when offline; instead, store such data directly into the local user defaults database.
  */
+@available(iOS 15.0, watchOS 9.0, macOS 11.0, tvOS 15.0, *)
 @propertyWrapper public struct SyncState<Value: Codable>: DynamicProperty {
     /// Holds the singleton instance of `Application`.
     @ObservedObject private var app: Application = Application.shared

--- a/Tests/AppStateTests/SyncStateTests.swift
+++ b/Tests/AppStateTests/SyncStateTests.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import XCTest
 @testable import AppState
 
+@available(iOS 15.0, watchOS 9.0, macOS 11.0, tvOS 15.0, *)
 fileprivate extension Application {
     var syncValue: SyncState<Int?> {
         syncState(id: "syncValue")
@@ -12,14 +13,19 @@ fileprivate extension Application {
     }
 }
 
+@available(iOS 15.0, watchOS 9.0, macOS 11.0, tvOS 15.0, *)
 fileprivate struct ExampleSyncValue {
     @SyncState(\.syncValue) var count
 }
 
+
+@available(iOS 15.0, watchOS 9.0, macOS 11.0, tvOS 15.0, *)
 fileprivate struct ExampleFailureSyncValue {
     @SyncState(\.syncFailureValue) var count
 }
 
+
+@available(iOS 15.0, watchOS 9.0, macOS 11.0, tvOS 15.0, *)
 fileprivate class ExampleStoringViewModel: ObservableObject {
     @SyncState(\.syncValue) var count
 
@@ -33,6 +39,8 @@ fileprivate class ExampleStoringViewModel: ObservableObject {
     }
 }
 
+
+@available(iOS 15.0, watchOS 9.0, macOS 11.0, tvOS 15.0, *)
 final class SyncStateTests: XCTestCase {
     override class func setUp() {
         Application.logging(isEnabled: true)


### PR DESCRIPTION
Reduced the platform versions needed. Only special OS is watchOS, needing watchOS 9 to use SyncState.