### PR TITLE
Leif/dependency improvements

### DIFF
--- a/Sources/AppState/Application/Application+public.swift
+++ b/Sources/AppState/Application/Application+public.swift
@@ -181,7 +181,7 @@ public extension Application {
      - Returns: The requested dependency of type `Dependency<Value>`.
      */
     func dependency<Value>(
-        _ object: @autoclosure () -> Value,
+        _ object: () -> Value,
         feature: String = "App",
         id: String
     ) -> Dependency<Value> {
@@ -201,6 +201,42 @@ public extension Application {
         }
 
         return dependency
+    }
+
+    /// Overloaded version of `dependency(_:feature:id:)` function where id is generated from the code context.
+    func dependency<Value>(
+        setup: () -> Value,
+        _ fileID: StaticString = #fileID,
+        _ function: StaticString = #function,
+        _ line: Int = #line,
+        _ column: Int = #column
+    ) -> Dependency<Value> {
+        dependency(
+            setup,
+            id: Application.codeID(
+                fileID: fileID,
+                function: function,
+                line: line,
+                column: column
+            )
+        )
+    }
+
+    /**
+     Retrieves a dependency for the provided `id`. If dependency is not present, it is created once using the provided closure.
+
+     - Parameters:
+     - object: The closure returning the dependency.
+     - feature: The name of the feature to which the dependency belongs, default is "App".
+     - id: The specific identifier for this dependency.
+     - Returns: The requested dependency of type `Dependency<Value>`.
+     */
+    func dependency<Value>(
+        _ object: @autoclosure () -> Value,
+        feature: String = "App",
+        id: String
+    ) -> Dependency<Value> {
+        dependency(object, feature: feature, id: id)
     }
 
 

--- a/Sources/AppState/Application/Application.swift
+++ b/Sources/AppState/Application/Application.swift
@@ -93,15 +93,6 @@ open class Application: NSObject, ObservableObject {
         loadDefaultDependencies()
 
         consume(object: cache)
-
-        if #available(iOS 15.0, watchOS 9.0, macOS 11.0, tvOS 15.0, *) {
-            NotificationCenter.default.addObserver(
-                self,
-                selector: #selector(didChangeExternally),
-                name: NSUbiquitousKeyValueStore.didChangeExternallyNotification,
-                object: NSUbiquitousKeyValueStore.default
-            )
-        }
     }
 
     @objc @available(iOS 15.0, watchOS 9.0, macOS 11.0, tvOS 15.0, *)

--- a/Sources/AppState/Application/Types/Application+SyncState.swift
+++ b/Sources/AppState/Application/Types/Application+SyncState.swift
@@ -4,7 +4,16 @@ import Foundation
 extension Application {
     /// The default `NSUbiquitousKeyValueStore` instance.
     public var icloudStore: Dependency<NSUbiquitousKeyValueStore> {
-        dependency(NSUbiquitousKeyValueStore.default)
+        dependency {
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(didChangeExternally),
+                name: NSUbiquitousKeyValueStore.didChangeExternallyNotification,
+                object: NSUbiquitousKeyValueStore.default
+            )
+
+            return NSUbiquitousKeyValueStore.default
+        }
     }
 
     /**


### PR DESCRIPTION
This change allows for a trailing closure syntax when creating dependencies. This change also moved the addObserver of the notification `NSUbiquitousKeyValueStore.didChangeExternallyNotification` from the init to when `icloudStore` is first initialized.

```swift
@available(iOS 15.0, watchOS 9.0, macOS 11.0, tvOS 15.0, *)
extension Application {
    /// The default `NSUbiquitousKeyValueStore` instance.
    public var icloudStore: Dependency<NSUbiquitousKeyValueStore> {
        dependency {
            NotificationCenter.default.addObserver(
                self,
                selector: #selector(didChangeExternally),
                name: NSUbiquitousKeyValueStore.didChangeExternallyNotification,
                object: NSUbiquitousKeyValueStore.default
            )

            return NSUbiquitousKeyValueStore.default
        }
    }
}
```

This resolves a potential log error when you don't have the correct entitlement file.

> Unable to find entitlement for KVS store
>
> BUG IN CLIENT OF KVS: Trying to initialize NSUbiquitousKeyValueStore without a store identifier. Please specify your store identifier in the 'com.apple.developer.ubiquity-kvstore-identifier' entitlement.