### PR TITLE
Add Slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ AppState is a Swift Package that simplifies the management of application state 
 
 - **Slice (property wrapper):** A property wrapper that allows users to access and modify a specific part of an AppState's state. This provides a more fine-grained control over the AppState and makes it easier to manage complex states.
 
+- **Constant (property wrapper):** A property wrapper that allows users to access a specific part of an AppState's state. This provides a more fine-grained control over the AppState and makes it easier to manage complex states.
+
 - **SecureState (property wrapper):** A property wrapper that securely stores its string values using the Keychain. Provides the same integration benefits as AppState.
 
 - **AppDependency (property wrapper):** A property wrapper that simplifies the handling of dependencies throughout your application.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ AppState is a Swift Package that simplifies the management of application state 
 
 - **SyncState:** Dedicated struct type for encapsulating and broadcasting stored value changes within the app's scope. Values are stored using `iCloud`. Requires iOS 15.0, watchOS 9.0, macOS 11.0, or tvOS 15.0.
 
+- **Slice:** Dedicated struct has the ability to access and modify a specific part of an AppState's state, providing a more fine-grained control over the AppState.
+
 - **SecureState:** Dedicated struct type for securely encapsulating and broadcasting stored value changes within the app's scope. Values are securely stored using the device's Keychain. SecureState values are never stored in the cache and are always retrieved directly from the Keychain.
 
 - **Dependency:** Dedicated struct type for encapsulating dependencies within the app's scope.
@@ -23,6 +25,8 @@ AppState is a Swift Package that simplifies the management of application state 
 - **StoredState (property wrapper):** A property wrapper that stores its values to `UserDefaults`. Works the same as `AppState` otherwise.
 
 - **SyncState (property wrapper):** A property wrapper that stores its values to `iCloud`. Works the same as `AppState` otherwise. Requires iOS 15.0, watchOS 9.0, macOS 11.0, or tvOS 15.0.
+
+- **Slice (property wrapper):** A property wrapper that allows users to access and modify a specific part of an AppState's state. This provides a more fine-grained control over the AppState and makes it easier to manage complex states.
 
 - **SecureState (property wrapper):** A property wrapper that securely stores its string values using the Keychain. Provides the same integration benefits as AppState.
 

--- a/Sources/AppState/Application/Application+public.swift
+++ b/Sources/AppState/Application/Application+public.swift
@@ -665,7 +665,7 @@ extension Application {
 
      - Returns: A Slice that allows access to a specific part of an AppState's state.
      */
-    public static func slice<SlicedState: MutableCachedApplicationValue, Value, SliceValue>(
+    public static func slice<SlicedState: MutableApplicationState, Value, SliceValue>(
         _ stateKeyPath: KeyPath<Application, SlicedState>,
         _ valueKeyPath: KeyPath<Value, SliceValue>,
         _ fileID: StaticString = #fileID,
@@ -710,7 +710,7 @@ extension Application {
 
      - Returns: A Slice that allows access and modification to a specific part of an AppState's state.
      */
-    public static func slice<SlicedState: MutableCachedApplicationValue, Value, SliceValue>(
+    public static func slice<SlicedState: MutableApplicationState, Value, SliceValue>(
         _ stateKeyPath: KeyPath<Application, SlicedState>,
         _ valueKeyPath: WritableKeyPath<Value, SliceValue>,
         _ fileID: StaticString = #fileID,

--- a/Sources/AppState/Application/Application+public.swift
+++ b/Sources/AppState/Application/Application+public.swift
@@ -648,3 +648,41 @@ public extension Application {
         )
     }
 }
+
+// MARK: Slice Functions
+
+extension Application {
+    /// TODO: ...
+    public static func slice<SlicedState: MutableCachedApplicationValue, Value, SliceValue>(
+        _ stateKeyPath: KeyPath<Application, SlicedState>,
+        _ valueKeyPath: WritableKeyPath<Value, SliceValue>,
+        _ fileID: StaticString = #fileID,
+        _ function: StaticString = #function,
+        _ line: Int = #line,
+        _ column: Int = #column
+    ) -> Slice<SlicedState, Value, SliceValue> where SlicedState.Value == Value {
+
+        let slice = Slice(
+            stateKeyPath,
+            value: valueKeyPath
+        )
+
+        log(
+            debug: {
+                let stateKeyPathString = String(describing: stateKeyPath)
+                let valueTypeCharacterCount = String(describing: Value.self).count
+                var valueKeyPathString = String(describing: valueKeyPath)
+
+                valueKeyPathString.removeFirst(valueTypeCharacterCount + 1)
+
+                return "🍕 Getting Slice \(stateKeyPathString)\(valueKeyPathString) -> \(slice.value)"
+            },
+            fileID: fileID,
+            function: function,
+            line: line,
+            column: column
+        )
+
+        return slice
+    }
+}

--- a/Sources/AppState/Application/Application+public.swift
+++ b/Sources/AppState/Application/Application+public.swift
@@ -673,7 +673,6 @@ extension Application {
         _ line: Int = #line,
         _ column: Int = #column
     ) -> Slice<SlicedState, Value, SliceValue, KeyPath<Value, SliceValue>> where SlicedState.Value == Value {
-
         let slice = Slice(
             stateKeyPath,
             value: valueKeyPath
@@ -719,7 +718,6 @@ extension Application {
         _ line: Int = #line,
         _ column: Int = #column
     ) -> Slice<SlicedState, Value, SliceValue, WritableKeyPath<Value, SliceValue>> where SlicedState.Value == Value {
-
         let slice = Slice(
             stateKeyPath,
             value: valueKeyPath

--- a/Sources/AppState/Application/Application+public.swift
+++ b/Sources/AppState/Application/Application+public.swift
@@ -652,7 +652,65 @@ public extension Application {
 // MARK: Slice Functions
 
 extension Application {
-    /// TODO: ...
+    /**
+     This function creates a `Slice` of AppState that allows access to a specific part of the AppState's state. It provides granular control over the AppState.
+
+     - Parameters:
+         - stateKeyPath: A KeyPath pointing to the state in AppState that should be sliced.
+         - valueKeyPath: A KeyPath pointing to the specific part of the state that should be accessed.
+         - fileID: The identifier of the file.
+         - function: The name of the declaration.
+         - line: The line number on which it appears.
+         - column: The column number in which it begins.
+
+     - Returns: A Slice that allows access to a specific part of an AppState's state.
+     */
+    public static func slice<SlicedState: MutableCachedApplicationValue, Value, SliceValue>(
+        _ stateKeyPath: KeyPath<Application, SlicedState>,
+        _ valueKeyPath: KeyPath<Value, SliceValue>,
+        _ fileID: StaticString = #fileID,
+        _ function: StaticString = #function,
+        _ line: Int = #line,
+        _ column: Int = #column
+    ) -> Slice<SlicedState, Value, SliceValue, KeyPath<Value, SliceValue>> where SlicedState.Value == Value {
+
+        let slice = Slice(
+            stateKeyPath,
+            value: valueKeyPath
+        )
+
+        log(
+            debug: {
+                let stateKeyPathString = String(describing: stateKeyPath)
+                let valueTypeCharacterCount = String(describing: Value.self).count
+                var valueKeyPathString = String(describing: valueKeyPath)
+
+                valueKeyPathString.removeFirst(valueTypeCharacterCount + 1)
+
+                return "🍕 Getting Slice \(stateKeyPathString)\(valueKeyPathString) -> \(slice.value)"
+            },
+            fileID: fileID,
+            function: function,
+            line: line,
+            column: column
+        )
+
+        return slice
+    }
+
+    /**
+     This function creates a `Slice` of AppState that allows access and modification to a specific part of the AppState's state. It provides granular control over the AppState.
+
+     - Parameters:
+         - stateKeyPath: A KeyPath pointing to the state in AppState that should be sliced.
+         - valueKeyPath: A WritableKeyPath pointing to the specific part of the state that should be accessed.
+         - fileID: The identifier of the file.
+         - function: The name of the declaration.
+         - line: The line number on which it appears.
+         - column: The column number in which it begins.
+
+     - Returns: A Slice that allows access and modification to a specific part of an AppState's state.
+     */
     public static func slice<SlicedState: MutableCachedApplicationValue, Value, SliceValue>(
         _ stateKeyPath: KeyPath<Application, SlicedState>,
         _ valueKeyPath: WritableKeyPath<Value, SliceValue>,
@@ -660,7 +718,7 @@ extension Application {
         _ function: StaticString = #function,
         _ line: Int = #line,
         _ column: Int = #column
-    ) -> Slice<SlicedState, Value, SliceValue> where SlicedState.Value == Value {
+    ) -> Slice<SlicedState, Value, SliceValue, WritableKeyPath<Value, SliceValue>> where SlicedState.Value == Value {
 
         let slice = Slice(
             stateKeyPath,

--- a/Sources/AppState/Application/Application.swift
+++ b/Sources/AppState/Application/Application.swift
@@ -34,20 +34,39 @@ open class Application: NSObject, ObservableObject {
         line: Int,
         column: Int
     ) {
+        log(
+            debug: { message },
+            fileID: fileID,
+            function: function,
+            line: line,
+            column: column
+        )
+    }
+
+    /// Internal log function.
+    static func log(
+        debug message: () -> String,
+        fileID: StaticString,
+        function: StaticString,
+        line: Int,
+        column: Int
+    ) {
         guard isLoggingEnabled else { return }
 
         let excludedFileIDs: [String] = [
             "AppState/Application+StoredState.swift",
             "AppState/Application+SyncState.swift",
-            "AppState/Application+SecureState.swift"
+            "AppState/Application+SecureState.swift",
+            "AppState/Application+Slice.swift"
         ]
         let isFileIDValue: Bool = excludedFileIDs.contains(fileID.description) == false
 
         guard isFileIDValue else { return }
 
+        let debugMessage = message()
         let codeID = codeID(fileID: fileID, function: function, line: line, column: column)
 
-        logger.debug("\(message) (\(codeID))")
+        logger.debug("\(debugMessage) (\(codeID))")
     }
 
     /// Internal log function.

--- a/Sources/AppState/Application/Types/Application+Slice.swift
+++ b/Sources/AppState/Application/Types/Application+Slice.swift
@@ -1,22 +1,36 @@
 extension Application {
-    /// TODO: ...
-    public struct Slice<SlicedState: MutableCachedApplicationValue, Value, SliceValue> where SlicedState.Value == Value {
+    /// `Slice` allows access and modification to a specific part of an AppState's state. Supports `State`, `SyncState`, and `StorageState`.
+    public struct Slice<
+        SlicedState: MutableCachedApplicationValue,
+        Value,
+        SliceValue,
+        SliceKeyPath: KeyPath<Value, SliceValue>
+    > where SlicedState.Value == Value {
         /// A private backing storage for the value.
         private var state: SlicedState
-        private let keyPath: WritableKeyPath<Value, SliceValue>
-
-        /// The current state value.
-        public var value: SliceValue {
-            get { state.value[keyPath: keyPath] }
-            set { state.value[keyPath: keyPath] = newValue }
-        }
+        private let keyPath: SliceKeyPath
 
         init(
             _ stateKeyPath: KeyPath<Application, SlicedState>,
-            value valueKeyPath: WritableKeyPath<Value, SliceValue>
+            value valueKeyPath: SliceKeyPath
         ) {
             self.state = shared.value(keyPath: stateKeyPath)
             self.keyPath = valueKeyPath
         }
+    }
+}
+
+extension Application.Slice where SliceKeyPath == KeyPath<Value, SliceValue> {
+    /// The current state value.
+    public var value: SliceValue {
+        state.value[keyPath: keyPath]
+    }
+}
+
+extension Application.Slice where SliceKeyPath == WritableKeyPath<Value, SliceValue> {
+    /// The current state value.
+    public var value: SliceValue {
+        get { state.value[keyPath: keyPath] }
+        set { state.value[keyPath: keyPath] = newValue }
     }
 }

--- a/Sources/AppState/Application/Types/Application+Slice.swift
+++ b/Sources/AppState/Application/Types/Application+Slice.swift
@@ -1,0 +1,22 @@
+extension Application {
+    /// TODO: ...
+    public struct Slice<SlicedState: MutableCachedApplicationValue, Value, SliceValue> where SlicedState.Value == Value {
+        /// A private backing storage for the value.
+        private var state: SlicedState
+        private let keyPath: WritableKeyPath<Value, SliceValue>
+
+        /// The current state value.
+        public var value: SliceValue {
+            get { state.value[keyPath: keyPath] }
+            set { state.value[keyPath: keyPath] = newValue }
+        }
+
+        init(
+            _ stateKeyPath: KeyPath<Application, SlicedState>,
+            value valueKeyPath: WritableKeyPath<Value, SliceValue>
+        ) {
+            self.state = shared.value(keyPath: stateKeyPath)
+            self.keyPath = valueKeyPath
+        }
+    }
+}

--- a/Sources/AppState/Application/Types/Application+Slice.swift
+++ b/Sources/AppState/Application/Types/Application+Slice.swift
@@ -1,7 +1,7 @@
 extension Application {
     /// `Slice` allows access and modification to a specific part of an AppState's state. Supports `State`, `SyncState`, and `StorageState`.
     public struct Slice<
-        SlicedState: MutableCachedApplicationValue,
+        SlicedState: MutableApplicationState,
         Value,
         SliceValue,
         SliceKeyPath: KeyPath<Value, SliceValue>

--- a/Sources/AppState/Application/Types/Application+State.swift
+++ b/Sources/AppState/Application/Types/Application+State.swift
@@ -1,6 +1,6 @@
 extension Application {
     /// `State` encapsulates the value within the application's scope and allows any changes to be propagated throughout the scoped area.
-    public struct State<Value>: CustomStringConvertible {
+    public struct State<Value>: MutableCachedApplicationValue, CustomStringConvertible {
         enum StateType {
             case state
             case stored

--- a/Sources/AppState/Application/Types/Application+State.swift
+++ b/Sources/AppState/Application/Types/Application+State.swift
@@ -1,6 +1,6 @@
 extension Application {
     /// `State` encapsulates the value within the application's scope and allows any changes to be propagated throughout the scoped area.
-    public struct State<Value>: MutableCachedApplicationValue, CustomStringConvertible {
+    public struct State<Value>: MutableApplicationState, CustomStringConvertible {
         enum StateType {
             case state
             case stored

--- a/Sources/AppState/Application/Types/Application+StoredState.swift
+++ b/Sources/AppState/Application/Types/Application+StoredState.swift
@@ -7,7 +7,7 @@ extension Application {
     }
 
     /// `StoredState` encapsulates the value within the application's scope and allows any changes to be propagated throughout the scoped area.  State is stored using `UserDefaults`.
-    public struct StoredState<Value> {
+    public struct StoredState<Value>: MutableCachedApplicationValue {
         @AppDependency(\.userDefaults) private var userDefaults: UserDefaults
 
         /// The initial value of the state.

--- a/Sources/AppState/Application/Types/Application+StoredState.swift
+++ b/Sources/AppState/Application/Types/Application+StoredState.swift
@@ -7,7 +7,7 @@ extension Application {
     }
 
     /// `StoredState` encapsulates the value within the application's scope and allows any changes to be propagated throughout the scoped area.  State is stored using `UserDefaults`.
-    public struct StoredState<Value>: MutableCachedApplicationValue {
+    public struct StoredState<Value>: MutableApplicationState {
         @AppDependency(\.userDefaults) private var userDefaults: UserDefaults
 
         /// The initial value of the state.

--- a/Sources/AppState/Application/Types/Application+SyncState.swift
+++ b/Sources/AppState/Application/Types/Application+SyncState.swift
@@ -32,7 +32,7 @@ extension Application {
 
      - Warning: Avoid using this class for data that is essential to your app’s behavior when offline; instead, store such data directly into the local user defaults database.
      */
-    public struct SyncState<Value: Codable>: MutableCachedApplicationValue {
+    public struct SyncState<Value: Codable>: MutableApplicationState {
         @AppDependency(\.icloudStore) private var icloudStore: NSUbiquitousKeyValueStore
 
         /// The initial value of the state.

--- a/Sources/AppState/Application/Types/Application+SyncState.swift
+++ b/Sources/AppState/Application/Types/Application+SyncState.swift
@@ -32,7 +32,7 @@ extension Application {
 
      - Warning: Avoid using this class for data that is essential to your app’s behavior when offline; instead, store such data directly into the local user defaults database.
      */
-    public struct SyncState<Value: Codable> {
+    public struct SyncState<Value: Codable>: MutableCachedApplicationValue {
         @AppDependency(\.icloudStore) private var icloudStore: NSUbiquitousKeyValueStore
 
         /// The initial value of the state.

--- a/Sources/AppState/Application/Types/MutableApplicationState.swift
+++ b/Sources/AppState/Application/Types/MutableApplicationState.swift
@@ -1,4 +1,4 @@
-public protocol MutableCachedApplicationValue {
+public protocol MutableApplicationState {
     associatedtype Value
 
     var value: Value { get set }

--- a/Sources/AppState/Application/Types/MutableCachedApplicationValue.swift
+++ b/Sources/AppState/Application/Types/MutableCachedApplicationValue.swift
@@ -1,0 +1,5 @@
+public protocol MutableCachedApplicationValue {
+    associatedtype Value
+
+    var value: Value { get set }
+}

--- a/Sources/AppState/PropertyWrappers/Constant.swift
+++ b/Sources/AppState/PropertyWrappers/Constant.swift
@@ -1,0 +1,63 @@
+import Combine
+import SwiftUI
+
+/// A property wrapper that provides access to a specific part of the AppState's state.
+@propertyWrapper public struct Constant<SlicedState: MutableCachedApplicationValue, Value, SliceValue> where SlicedState.Value == Value {
+    /// Holds the singleton instance of `Application`.
+    @ObservedObject private var app: Application = Application.shared
+
+    /// Path for accessing `State` from Application.
+    private let stateKeyPath: KeyPath<Application, SlicedState>
+
+    /// Path for accessing `SliceValue` from `Value`.
+    private let valueKeyPath: KeyPath<Value, SliceValue>
+
+    private let fileID: StaticString
+    private let function: StaticString
+    private let line: Int
+    private let column: Int
+    private let sliceKeyPath: String
+
+    /// Represents the current value of the `State`.
+    public var wrappedValue: SliceValue {
+        Application.slice(
+            stateKeyPath,
+            valueKeyPath,
+            fileID,
+            function,
+            line,
+            column
+        ).value
+    }
+
+    /**
+     Initializes a Constant with the provided parameters. This constructor is used to create a Constant that provides access to a specific part of an AppState's state. It provides granular control over the AppState.
+
+     - Parameters:
+         - stateKeyPath: A KeyPath that points to the state in AppState that should be sliced.
+         - valueKeyPath: A KeyPath that points to the specific part of the state that should be accessed.
+     */
+    public init(
+        _ stateKeyPath: KeyPath<Application, SlicedState>,
+        _ valueKeyPath: KeyPath<Value, SliceValue>,
+        _ fileID: StaticString = #fileID,
+        _ function: StaticString = #function,
+        _ line: Int = #line,
+        _ column: Int = #column
+    ) {
+        self.stateKeyPath = stateKeyPath
+        self.valueKeyPath = valueKeyPath
+        self.fileID = fileID
+        self.function = function
+        self.line = line
+        self.column = column
+
+        let stateKeyPathString = String(describing: stateKeyPath)
+        let valueTypeCharacterCount = String(describing: Value.self).count
+        var valueKeyPathString = String(describing: valueKeyPath)
+
+        valueKeyPathString.removeFirst(valueTypeCharacterCount + 1)
+
+        self.sliceKeyPath = "\(stateKeyPathString)\(valueKeyPathString)"
+    }
+}

--- a/Sources/AppState/PropertyWrappers/Constant.swift
+++ b/Sources/AppState/PropertyWrappers/Constant.swift
@@ -2,7 +2,7 @@ import Combine
 import SwiftUI
 
 /// A property wrapper that provides access to a specific part of the AppState's state.
-@propertyWrapper public struct Constant<SlicedState: MutableCachedApplicationValue, Value, SliceValue> where SlicedState.Value == Value {
+@propertyWrapper public struct Constant<SlicedState: MutableApplicationState, Value, SliceValue> where SlicedState.Value == Value {
     /// Holds the singleton instance of `Application`.
     @ObservedObject private var app: Application = Application.shared
 

--- a/Sources/AppState/PropertyWrappers/Slice.swift
+++ b/Sources/AppState/PropertyWrappers/Slice.swift
@@ -1,0 +1,96 @@
+import Combine
+import SwiftUI
+
+@propertyWrapper public struct Slice<SlicedState: MutableCachedApplicationValue, Value, SliceValue>: DynamicProperty where SlicedState.Value == Value {
+    /// Holds the singleton instance of `Application`.
+    @ObservedObject private var app: Application = Application.shared
+
+    /// Path for accessing `State` from Application.
+    private let stateKeyPath: KeyPath<Application, SlicedState>
+
+    /// Path for accessing `SliceValue` from `Value`.
+    private let valueKeyPath: WritableKeyPath<Value, SliceValue>
+
+    private let fileID: StaticString
+    private let function: StaticString
+    private let line: Int
+    private let column: Int
+    private let sliceKeyPath: String
+
+    /// Represents the current value of the `State`.
+    public var wrappedValue: SliceValue {
+        get {
+            Application.slice(
+                stateKeyPath,
+                valueKeyPath,
+                fileID,
+                function,
+                line,
+                column
+            ).value
+        }
+        nonmutating set {
+            Application.log(
+                debug: "🍕 Setting Slice \(sliceKeyPath) = \(newValue)",
+                fileID: fileID,
+                function: function,
+                line: line,
+                column: column
+            )
+
+            var state = app.value(keyPath: stateKeyPath)
+            state.value[keyPath: valueKeyPath] = newValue
+        }
+    }
+
+    /// A binding to the `State`'s value, which can be used with SwiftUI views.
+    public var projectedValue: Binding<SliceValue> {
+        Binding(
+            get: { wrappedValue },
+            set: { wrappedValue = $0 }
+        )
+    }
+
+    public init(
+        _ stateKeyPath: KeyPath<Application, SlicedState>,
+        _ valueKeyPath: WritableKeyPath<Value, SliceValue>,
+        _ fileID: StaticString = #fileID,
+        _ function: StaticString = #function,
+        _ line: Int = #line,
+        _ column: Int = #column
+    ) {
+        self.stateKeyPath = stateKeyPath
+        self.valueKeyPath = valueKeyPath
+        self.fileID = fileID
+        self.function = function
+        self.line = line
+        self.column = column
+
+        let stateKeyPathString = String(describing: stateKeyPath)
+        let valueTypeCharacterCount = String(describing: Value.self).count
+        var valueKeyPathString = String(describing: valueKeyPath)
+
+        valueKeyPathString.removeFirst(valueTypeCharacterCount + 1)
+
+        self.sliceKeyPath = "\(stateKeyPathString)\(valueKeyPathString)"
+    }
+
+    /// A property wrapper's synthetic storage property. This is just for SwiftUI to mutate the `wrappedValue` and send event through `objectWillChange` publisher when the `wrappedValue` changes
+    public static subscript<OuterSelf: ObservableObject>(
+        _enclosingInstance observed: OuterSelf,
+        wrapped wrappedKeyPath: ReferenceWritableKeyPath<OuterSelf, SliceValue>,
+        storage storageKeyPath: ReferenceWritableKeyPath<OuterSelf, Self>
+    ) -> SliceValue {
+        get {
+            observed[keyPath: storageKeyPath].wrappedValue
+        }
+        set {
+            guard
+                let publisher = observed.objectWillChange as? ObservableObjectPublisher
+            else { return }
+
+            publisher.send()
+            observed[keyPath: storageKeyPath].wrappedValue = newValue
+        }
+    }
+}

--- a/Sources/AppState/PropertyWrappers/Slice.swift
+++ b/Sources/AppState/PropertyWrappers/Slice.swift
@@ -1,6 +1,7 @@
 import Combine
 import SwiftUI
 
+/// A property wrapper that provides access to a specific part of the AppState's state.
 @propertyWrapper public struct Slice<SlicedState: MutableCachedApplicationValue, Value, SliceValue>: DynamicProperty where SlicedState.Value == Value {
     /// Holds the singleton instance of `Application`.
     @ObservedObject private var app: Application = Application.shared
@@ -51,6 +52,13 @@ import SwiftUI
         )
     }
 
+    /**
+     Initializes a Slice with the provided parameters. This constructor is used to create a Slice that provides access and modification to a specific part of an AppState's state. It provides granular control over the AppState.
+
+     - Parameters:
+         - stateKeyPath: A KeyPath that points to the state in AppState that should be sliced.
+         - valueKeyPath: A WritableKeyPath that points to the specific part of the state that should be accessed.
+     */
     public init(
         _ stateKeyPath: KeyPath<Application, SlicedState>,
         _ valueKeyPath: WritableKeyPath<Value, SliceValue>,

--- a/Sources/AppState/PropertyWrappers/Slice.swift
+++ b/Sources/AppState/PropertyWrappers/Slice.swift
@@ -2,7 +2,7 @@ import Combine
 import SwiftUI
 
 /// A property wrapper that provides access to a specific part of the AppState's state.
-@propertyWrapper public struct Slice<SlicedState: MutableCachedApplicationValue, Value, SliceValue>: DynamicProperty where SlicedState.Value == Value {
+@propertyWrapper public struct Slice<SlicedState: MutableApplicationState, Value, SliceValue>: DynamicProperty where SlicedState.Value == Value {
     /// Holds the singleton instance of `Application`.
     @ObservedObject private var app: Application = Application.shared
 

--- a/Tests/AppStateTests/SliceTests.swift
+++ b/Tests/AppStateTests/SliceTests.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+import XCTest
+@testable import AppState
+
+struct ExampleValue {
+    var username: String
+    var isLoading: Bool
+}
+
+fileprivate extension Application {
+    var exampleValue: State<ExampleValue> {
+        state(
+            initial: ExampleValue(
+                username: "Leif",
+                isLoading: false
+            )
+        )
+    }
+}
+
+fileprivate class ExampleViewModel: ObservableObject {
+    @Slice(\.exampleValue, \.username) var username
+    
+    func testPropertyWrapper() {
+        username = "Hello, ExampleView"
+    }
+}
+
+fileprivate struct ExampleView: View {
+    @Slice(\.exampleValue, \.username) var username
+    @Slice(\.exampleValue, \.isLoading) var isLoading
+    
+    var body: some View { fatalError() }
+    
+    func testPropertyWrappers() {
+        username = "Hello, ExampleView"
+        _ = Toggle(isOn: $isLoading) {
+            Text("Is Loading")
+        }
+    }
+}
+
+final class SliceTests: XCTestCase {
+    override class func setUp() {
+        Application.logging(isEnabled: true)
+    }
+    
+    override class func tearDown() {
+        Application.logger.debug("AppStateTests \(Application.description)")
+    }
+    
+    func testPropertyWrappers() {
+        let exampleView = ExampleView()
+        
+        XCTAssertEqual(exampleView.username, "Leif")
+        
+        exampleView.testPropertyWrappers()
+        
+        XCTAssertEqual(exampleView.username, "Hello, ExampleView")
+        
+        let viewModel = ExampleViewModel()
+        
+        XCTAssertEqual(viewModel.username, "Hello, ExampleView")
+        
+        viewModel.username = "Hello, ViewModel"
+        
+        XCTAssertEqual(viewModel.username, "Hello, ViewModel")
+    }
+}

--- a/Tests/AppStateTests/SliceTests.swift
+++ b/Tests/AppStateTests/SliceTests.swift
@@ -5,6 +5,7 @@ import XCTest
 struct ExampleValue {
     var username: String
     var isLoading: Bool
+    let value: String
 }
 
 fileprivate extension Application {
@@ -12,7 +13,8 @@ fileprivate extension Application {
         state(
             initial: ExampleValue(
                 username: "Leif",
-                isLoading: false
+                isLoading: false,
+                value: "value"
             )
         )
     }
@@ -20,7 +22,8 @@ fileprivate extension Application {
 
 fileprivate class ExampleViewModel: ObservableObject {
     @Slice(\.exampleValue, \.username) var username
-    
+    @Constant(\.exampleValue, \.value) var value
+
     func testPropertyWrapper() {
         username = "Hello, ExampleView"
     }
@@ -65,5 +68,7 @@ final class SliceTests: XCTestCase {
         viewModel.username = "Hello, ViewModel"
         
         XCTAssertEqual(viewModel.username, "Hello, ViewModel")
+
+        XCTAssertEqual(viewModel.value, "value")
     }
 }

--- a/Tests/AppStateTests/SliceTests.swift
+++ b/Tests/AppStateTests/SliceTests.swift
@@ -51,7 +51,23 @@ final class SliceTests: XCTestCase {
     override class func tearDown() {
         Application.logger.debug("AppStateTests \(Application.description)")
     }
-    
+
+    func testApplicationSliceFunction() {
+        var exampleSlice = Application.slice(\.exampleValue, \.username)
+
+        exampleSlice.value = "New Value!"
+
+        XCTAssertEqual(exampleSlice.value, "New Value!")
+        XCTAssertEqual(Application.slice(\.exampleValue, \.username).value, "New Value!")
+        XCTAssertEqual(Application.state(\.exampleValue).value.username, "New Value!")
+
+        exampleSlice.value = "Leif"
+
+        XCTAssertEqual(exampleSlice.value, "Leif")
+        XCTAssertEqual(Application.slice(\.exampleValue, \.username).value, "Leif")
+        XCTAssertEqual(Application.state(\.exampleValue).value.username, "Leif")
+    }
+
     func testPropertyWrappers() {
         let exampleView = ExampleView()
         


### PR DESCRIPTION
## Introducing Slice in AppState

AppState introduces a new feature called Slice. This feature allows users to access and modify a specific part of an AppState's state, providing a more fine-grained control over the AppState.

Here is a simplified example of how to use Slice in a SwiftUI application:

```swift
import AppState
import SwiftUI

struct User {
    let id: String = UUID().uuidString
    var username: String
}

fileprivate extension Application {
    var user: State<User> {
        state(
            initial: User(username: "John")
        )
    }
}

fileprivate struct UserProfileView: View {
    @Slice(\.user, \.username) var username
    @Constant(\.user, \.id) var id

    var body: some View {
        Text("Username: \(username)")
    }
}
```

In the example above, `UserProfileView` uses the `@Slice` property wrapper to access the `username` property of the `user` state. Any changes made to `username` will be reflected in the `user` state.