### PR TITLE
Addressing State being consistent in value from the first check (#90)

### DIFF
--- a/Sources/AppState/Application/Types/State/Application+State.swift
+++ b/Sources/AppState/Application/Types/State/Application+State.swift
@@ -22,30 +22,25 @@ extension Application {
                     )
                 else {
                     defer {
+                        let setValue = {
+                            shared.cache.set(
+                                value: Application.State(
+                                    type: .state,
+                                    initial: _value,
+                                    scope: scope
+                                ),
+                                forKey: scope.key
+                            )
+                        }
+
                         #if !os(Linux) && !os(Windows)
                         Task {
                             await MainActor.run {
-                                shared.cache.set(
-                                    value: Application.State(
-                                        type: .state,
-                                        initial: _value,
-                                        scope: scope
-                                    ),
-                                    forKey: scope.key
-                                )
+                                setValue()
                             }
                         }
-     
                         #else
-                        shared.cache.set(
-                            value: Application.State(
-                                type: .state,
-                                initial: _value,
-                                scope: scope
-                            ),
-                            forKey: scope.key
-                        )
-
+                        setValue()
                         #endif
                     }
                     return _value

--- a/Sources/AppState/Application/Types/State/Application+State.swift
+++ b/Sources/AppState/Application/Types/State/Application+State.swift
@@ -20,8 +20,36 @@ extension Application {
                         scope.key,
                         as: State<Value>.self
                     )
-                else { return _value }
+                else {
+                    defer {
+                        #if !os(Linux) && !os(Windows)
+                        Task {
+                            await MainActor.run {
+                                shared.cache.set(
+                                    value: Application.State(
+                                        type: .state,
+                                        initial: _value,
+                                        scope: scope
+                                    ),
+                                    forKey: scope.key
+                                )
+                            }
+                        }
+     
+                        #else
+                        shared.cache.set(
+                            value: Application.State(
+                                type: .state,
+                                initial: _value,
+                                scope: scope
+                            ),
+                            forKey: scope.key
+                        )
 
+                        #endif
+                    }
+                    return _value
+                }
                 return state._value
             }
             set {

--- a/Tests/AppStateTests/AppStateTests.swift
+++ b/Tests/AppStateTests/AppStateTests.swift
@@ -13,9 +13,11 @@ fileprivate extension Application {
     var username: State<String> {
         state(initial: "Leif")
     }
+    
     var date: State<Date> {
         state(initial: Date())
     }
+    
     var colors: State<[String: String]> {
         state(initial: ["primary": "#A020F0"])
     }

--- a/Tests/AppStateTests/AppStateTests.swift
+++ b/Tests/AppStateTests/AppStateTests.swift
@@ -13,7 +13,9 @@ fileprivate extension Application {
     var username: State<String> {
         state(initial: "Leif")
     }
-
+    var date: State<Date> {
+        state(initial: Date())
+    }
     var colors: State<[String: String]> {
         state(initial: ["primary": "#A020F0"])
     }
@@ -68,6 +70,23 @@ final class AppStateTests: XCTestCase {
 
         XCTAssertEqual(appState.value, "0xL")
         XCTAssertEqual(Application.state(\.username).value, "0xL")
+    }
+    
+    func testStateClosureCachesValueOnGet() async {
+        let dateState: Application.State = Application.state(\.date)
+        #if !os(Linux) && !os(Windows)
+        await MainActor.run {
+            let copyOfDateState: Application.State =
+            Application.state(\.date)
+            
+            XCTAssertEqual(copyOfDateState.value, dateState.value)
+        }
+        #else
+        let copyOfDateState: Application.State =
+        Application.state(\.date)
+        
+        XCTAssertEqual(copyOfDateState.value, dateState.value)
+        #endif
     }
 
     func testPropertyWrappers() {


### PR DESCRIPTION
* Update README.md

- change variable appState name to usernameState to reflect the value of the variable.

* Update README.md

- update appState variable name to usernameState for the whole read and write section

* Made changes to State to cache value when it is first retrieved. Added a test to ensure that state value is consistent from when it is first checked

* Made additions to testStateClosureCachesValueOnGet to account for async