### PR TITLE
Leif/preview improvements

### DIFF
--- a/Sources/AppState/Application/Application+public.swift
+++ b/Sources/AppState/Application/Application+public.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if !os(Linux) && !os(Windows)
+import SwiftUI
+#endif
 
 // MARK: Application Functions
 
@@ -292,6 +295,32 @@ public extension Application {
         )
     }
 }
+
+#if !os(Linux) && !os(Windows)
+// MARK: - SwiftUI Preview Dependency Functions
+
+public extension Application {
+    /**
+    Use in SwiftUI previews to inject mock dependencies into the content view.
+
+     - Parameters:
+        - dependencyOverrides: An array of `Application.override(_, with:)` outputs that you want to use for the preview.
+        - content: A closure that returns the View you want to preview.
+
+     - Returns: A View with the overridden dependencies applied.
+     */
+    @ViewBuilder
+    static func preview<Content: View>(
+        dependencyOverrides: [DependencyOverride],
+        content: @escaping () -> Content
+    ) -> some View {
+        ApplicationPreview(
+            dependencyOverrides: dependencyOverrides,
+            content: content
+        )
+    }
+}
+#endif
 
 // MARK: - State Functions
 

--- a/Sources/AppState/Application/Application+public.swift
+++ b/Sources/AppState/Application/Application+public.swift
@@ -311,7 +311,7 @@ public extension Application {
      */
     @ViewBuilder
     static func preview<Content: View>(
-        dependencyOverrides: [DependencyOverride],
+        _ dependencyOverrides: DependencyOverride...,
         content: @escaping () -> Content
     ) -> some View {
         ApplicationPreview(

--- a/Sources/AppState/Application/Types/Helper/Application+ApplicationPreview.swift
+++ b/Sources/AppState/Application/Types/Helper/Application+ApplicationPreview.swift
@@ -1,0 +1,22 @@
+#if !os(Linux) && !os(Windows)
+import SwiftUI
+
+extension Application {
+    struct ApplicationPreview<Content: View>: View {
+        let dependencyOverrides: [DependencyOverride]
+        let content: () -> Content
+
+        init(
+            dependencyOverrides: [DependencyOverride],
+            content: @escaping () -> Content
+        ) {
+            self.dependencyOverrides = dependencyOverrides
+            self.content = content
+        }
+
+        var body: some View {
+            content()
+        }
+    }
+}
+#endif


### PR DESCRIPTION
- Added new `Application.preview` to be used in `#Preview` to override the needed dependencies for the content view.

```swift
class Service {
    var title: String { "Live Service" }
}

class MockService: Service {
    override var title: String { "Mock Service" }
}

extension Application {
    var service: Dependency<Service> {
        dependency(Service())
    }
}

struct ContentView: View {
    @AppDependency(\.service) private var service

    var body: some View {
        Text(service.title)
    }
}

#Preview {
    Application.preview(
        Application.override(\.service, with: MockService()),
        Application.override(\.userDefaults, with: UserDefaults())
    ) {
        ContentView()
    }
}
```