### PR TITLE
Fix double slash is path

### DIFF
--- a/Sources/AppState/Application/Types/Helper/FileManager+AppState.swift
+++ b/Sources/AppState/Application/Types/Helper/FileManager+AppState.swift
@@ -10,7 +10,7 @@ extension FileManager {
 
         #if !os(Linux) && !os(Windows)
         if #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) {
-            return "\(path.path())/App"
+            return path.appending(path: "App").path()
         } else {
             return "\(path.path)/App"
         }


### PR DESCRIPTION
https://pubs.opengroup.org/onlinepubs/009695399/
>  3.266 Pathname
>
> A character string that is used to identify a file. In the context of IEEE Std 1003.1-2001, a pathname consists of, at most, {PATH_MAX} bytes, including the terminating null byte. It has an optional beginning slash, followed by zero or more filenames separated by slashes. A pathname may optionally contain one or more trailing slashes. Multiple successive slashes are considered to be the same as one slash. 