### PR TITLE
Use Task MainActor to queue up set call

### DIFF
--- a/Sources/AppState/Application/Types/State/Application+State.swift
+++ b/Sources/AppState/Application/Types/State/Application+State.swift
@@ -34,14 +34,16 @@ extension Application {
                     )
                 else {
                     defer {
-                        shared.cache.set(
-                            value: Application.State(
-                                type: .state,
-                                initial: _value,
-                                scope: scope
-                            ),
-                            forKey: scope.key
-                        )
+                        Task { @MainActor in
+                            shared.cache.set(
+                                value: Application.State(
+                                    type: .state,
+                                    initial: _value,
+                                    scope: scope
+                                ),
+                                forKey: scope.key
+                            )
+                        }
                     }
                     return _value
                 }

--- a/Sources/AppState/Application/Types/State/Application+State.swift
+++ b/Sources/AppState/Application/Types/State/Application+State.swift
@@ -34,7 +34,7 @@ extension Application {
                     )
                 else {
                     defer {
-                        Task { @MainActor in
+                        let setValue = {
                             shared.cache.set(
                                 value: Application.State(
                                     type: .state,
@@ -44,6 +44,17 @@ extension Application {
                                 forKey: scope.key
                             )
                         }
+                        #if (!os(Linux) && !os(Windows))
+                        if NSClassFromString("XCTest") == nil {
+                            Task { @MainActor in
+                                setValue()
+                            }
+                        } else {
+                            setValue()
+                        }
+                        #else
+                        setValue()
+                        #endif
                     }
                     return _value
                 }


### PR DESCRIPTION
This pull request includes a small change to the `Sources/AppState/Application/Types/State/Application+State.swift` file. The change ensures that a task is executed on the main actor, after the current MainActor task has finished, when setting the cache value.

* [`Sources/AppState/Application/Types/State/Application+State.swift`](diffhunk://#diff-87a28e9beb9eb6ae58611ad7b622f6c5747793c22794716c861ecc66ee3cdd99R37): Added a `Task` block with `@MainActor` to ensure the cache is set on the main actor. [[1]](diffhunk://#diff-87a28e9beb9eb6ae58611ad7b622f6c5747793c22794716c861ecc66ee3cdd99R37) [[2]](diffhunk://#diff-87a28e9beb9eb6ae58611ad7b622f6c5747793c22794716c861ecc66ee3cdd99R47)