### PR TITLE
Refactors logger to use dependency injection

### DIFF
--- a/Sources/AppState/Application/Application+internal.swift
+++ b/Sources/AppState/Application/Application+internal.swift
@@ -75,7 +75,7 @@ extension Application {
         let debugMessage = message()
         let codeID = codeID(fileID: fileID, function: function, line: line, column: column)
 
-        logger.debug("\(debugMessage) (\(codeID))")
+        Application.dependency(\.logger).debug("\(debugMessage) (\(codeID))")
     }
 
     /// Internal log function.
@@ -92,7 +92,7 @@ extension Application {
 
         let codeID = codeID(fileID: fileID, function: function, line: line, column: column)
 
-        logger.error(
+        Application.dependency(\.logger).error(
             """
             \(message) Error: {
                 ❌ \(error)

--- a/Sources/AppState/Application/Application+public.swift
+++ b/Sources/AppState/Application/Application+public.swift
@@ -143,13 +143,15 @@ public extension Application {
         _ line: Int = #line,
         _ column: Int = #column
     ) -> Value {
-        log(
-            debug: "🔗 Getting Dependency \(String(describing: keyPath))",
-            fileID: fileID,
-            function: function,
-            line: line,
-            column: column
-        )
+        if keyPath != \.logger {
+            log(
+                debug: "🔗 Getting Dependency \(String(describing: keyPath))",
+                fileID: fileID,
+                function: function,
+                line: line,
+                column: column
+            )
+        }
 
         return shared.value(keyPath: keyPath).value
     }

--- a/Sources/AppState/Application/Application.swift
+++ b/Sources/AppState/Application/Application.swift
@@ -14,12 +14,14 @@ open class Application: NSObject {
 
     #if !os(Linux) && !os(Windows)
     /// Logger specifically for AppState
-    @MainActor
-    public static let logger: Logger = Logger(subsystem: "AppState", category: "Application")
+    public var logger: Dependency<Logger> {
+        dependency(Logger(subsystem: "AppState", category: "Application"))
+    }
     #else
     /// Logger specifically for AppState
-    @MainActor
-    public static var logger: ApplicationLogger = ApplicationLogger()
+    public var logger: Dependency<ApplicationLogger> {
+        dependency(ApplicationLogger())
+    }
     #endif
 
     @MainActor
@@ -97,6 +99,7 @@ open class Application: NSObject {
 
     /// Loads the default dependencies for use in Application.
     private func loadDefaultDependencies() {
+        load(dependency: \.logger)
         load(dependency: \.userDefaults)
         load(dependency: \.fileManager)
     }

--- a/Tests/AppStateTests/AppDependencyTests.swift
+++ b/Tests/AppStateTests/AppDependencyTests.swift
@@ -51,7 +51,7 @@ final class AppDependencyTests: XCTestCase {
     override func tearDown() async throws {
         let applicationDescription = Application.description
 
-        Application.logger.debug("AppDependencyTests \(applicationDescription)")
+        Application.dependency(\.logger).debug("AppDependencyTests \(applicationDescription)")
     }
 
     func testComposableDependencies() {

--- a/Tests/AppStateTests/AppStateTests.swift
+++ b/Tests/AppStateTests/AppStateTests.swift
@@ -184,14 +184,14 @@ final class AppStateTests: XCTestCase {
     func testLoggingToggle() {
         // Assuming default is true from setUp
         XCTAssertTrue(Application.isLoggingEnabled)
-        Application.logger.debug("This should be logged from testLoggingToggle.")
+        Application.dependency(\.logger).debug("This should be logged from testLoggingToggle.")
 
         Application.logging(isEnabled: false)
         XCTAssertFalse(Application.isLoggingEnabled)
-        Application.logger.debug("This should NOT be logged from testLoggingToggle.") // This won't be asserted, just for manual check if needed
+        Application.dependency(\.logger).debug("This should NOT be logged from testLoggingToggle.") // This won't be asserted, just for manual check if needed
 
         Application.logging(isEnabled: true)
         XCTAssertTrue(Application.isLoggingEnabled)
-        Application.logger.debug("This should be logged again from testLoggingToggle.")
+        Application.dependency(\.logger).debug("This should be logged again from testLoggingToggle.")
     }
 }

--- a/Tests/AppStateTests/DependencySliceTests.swift
+++ b/Tests/AppStateTests/DependencySliceTests.swift
@@ -50,7 +50,7 @@ final class DependencySliceTests: XCTestCase {
     override func tearDown() async throws {
         let applicationDescription = Application.description
 
-        Application.logger.debug("DependencySliceTests \(applicationDescription)")
+        Application.dependency(\.logger).debug("DependencySliceTests \(applicationDescription)")
     }
 
     @MainActor

--- a/Tests/AppStateTests/FileStateTests.swift
+++ b/Tests/AppStateTests/FileStateTests.swift
@@ -57,7 +57,7 @@ final class FileStateTests: XCTestCase {
     override func tearDown() async throws {
         let applicationDescription = Application.description
 
-        Application.logger.debug("FileStateTests \(applicationDescription)")
+        Application.dependency(\.logger).debug("FileStateTests \(applicationDescription)")
 
         try? Application.dependency(\.fileManager).removeItem(atPath: "./AppStateTests")
     }
@@ -79,7 +79,7 @@ final class FileStateTests: XCTestCase {
         XCTAssertEqual(storedValue.count, 1)
         XCTAssertEqual(storedValue.storedString, "Hello")
 
-        Application.logger.debug("FileStateTests \(Application.description)")
+        Application.dependency(\.logger).debug("FileStateTests \(Application.description)")
 
         storedValue.count = nil
         storedValue.storedString = nil

--- a/Tests/AppStateTests/ObservedDependencyTests.swift
+++ b/Tests/AppStateTests/ObservedDependencyTests.swift
@@ -44,7 +44,7 @@ final class ObservedDependencyTests: XCTestCase {
     override func tearDown() async throws {
         let applicationDescription = Application.description
 
-        Application.logger.debug("ObservedDependencyTests \(applicationDescription)")
+        Application.dependency(\.logger).debug("ObservedDependencyTests \(applicationDescription)")
     }
 
     @MainActor

--- a/Tests/AppStateTests/OptionalSliceTests.swift
+++ b/Tests/AppStateTests/OptionalSliceTests.swift
@@ -62,7 +62,7 @@ final class OptionalSliceTests: XCTestCase {
     override func tearDown() async throws {
         let applicationDescription = Application.description
 
-        Application.logger.debug("AppStateTests \(applicationDescription)")
+        Application.dependency(\.logger).debug("AppStateTests \(applicationDescription)")
     }
 
     @MainActor

--- a/Tests/AppStateTests/SecureStateTests.swift
+++ b/Tests/AppStateTests/SecureStateTests.swift
@@ -36,7 +36,7 @@ final class SecureStateTests: XCTestCase {
     override func tearDown() async throws {
         let applicationDescription = Application.description
 
-        Application.logger.debug("SecureStateTests \(applicationDescription)")
+        Application.dependency(\.logger).debug("SecureStateTests \(applicationDescription)")
     }
 
     @MainActor
@@ -55,7 +55,7 @@ final class SecureStateTests: XCTestCase {
 
         XCTAssertNotEqual(secureValue.token, "QWERTY")
 
-        Application.logger.debug("SecureStateTests \(Application.description)")
+        Application.dependency(\.logger).debug("SecureStateTests \(Application.description)")
 
         secureValue.token = nil
 

--- a/Tests/AppStateTests/SliceTests.swift
+++ b/Tests/AppStateTests/SliceTests.swift
@@ -65,7 +65,7 @@ final class SliceTests: XCTestCase {
     override func tearDown() async throws {
         let applicationDescription = Application.description
 
-        Application.logger.debug("AppStateTests \(applicationDescription)")
+        Application.dependency(\.logger).debug("AppStateTests \(applicationDescription)")
     }
 
     @MainActor

--- a/Tests/AppStateTests/StoredStateTests.swift
+++ b/Tests/AppStateTests/StoredStateTests.swift
@@ -46,7 +46,7 @@ final class StoredStateTests: XCTestCase {
     override func tearDown() async throws {
         let applicationDescription = Application.description
 
-        Application.logger.debug("StoredStateTests \(applicationDescription)")
+        Application.dependency(\.logger).debug("StoredStateTests \(applicationDescription)")
     }
 
     @MainActor
@@ -61,7 +61,7 @@ final class StoredStateTests: XCTestCase {
 
         XCTAssertEqual(storedValue.count, 1)
 
-        Application.logger.debug("StoredStateTests \(Application.description)")
+        Application.dependency(\.logger).debug("StoredStateTests \(Application.description)")
 
         storedValue.count = nil
 

--- a/Tests/AppStateTests/SyncStateTests.swift
+++ b/Tests/AppStateTests/SyncStateTests.swift
@@ -57,7 +57,7 @@ final class SyncStateTests: XCTestCase {
     override func tearDown() async throws {
         let applicationDescription = Application.description
 
-        Application.logger.debug("SyncStateTests \(applicationDescription)")
+        Application.dependency(\.logger).debug("SyncStateTests \(applicationDescription)")
     }
 
     @MainActor
@@ -72,7 +72,7 @@ final class SyncStateTests: XCTestCase {
 
         XCTAssertEqual(syncValue.count, 1)
 
-        Application.logger.debug("SyncStateTests \(Application.description)")
+        Application.dependency(\.logger).debug("SyncStateTests \(Application.description)")
 
         syncValue.count = nil
 


### PR DESCRIPTION
Updates the logger to be a dependency managed by the `Application` class.
This allows for easier testing and customization of logging behavior.
Additionally, it removes the `@MainActor` requirement from the logger.
The logger dependency is now loaded by default.
A check prevents logging when retrieving the logger dependency itself, avoiding infinite recursion.

Closes #134
