### PR TITLE
Depend on Cache 2.1.3 instead of a revision pin

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,13 +26,8 @@ let package = Package(
         )
     ],
     dependencies: [
-        // Pin to the Cache commit that includes WebAssembly `canImport(Combine)` guards and the
-        // Linux/WASI collection-cast fix from 0xLeif/Cache#30. Switch back to a versioned
-        // `from:` pin once that PR is merged and tagged (e.g. 2.1.3+).
-        .package(
-            url: "https://github.com/0xLeif/Cache",
-            revision: "33ef0d77e144eaab0734b3da02c3fed6629166eb"
-        ),
+        // 2.1.3+: WebAssembly `canImport(Combine)` guards + Linux/WASI collection-cast fix.
+        .package(url: "https://github.com/0xLeif/Cache", from: "2.1.3"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.4.0")
     ],
     targets: [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Switches AppState’s Cache dependency from the temporary git revision pin to the tagged **[Cache 2.1.3](https://github.com/0xLeif/Cache/releases/tag/2.1.3)** release (WASM `canImport(Combine)` + Linux collection-cast fix).

```swift
.package(url: "https://github.com/0xLeif/Cache", from: "2.1.3")
```

## Test plan
- [ ] CI green: macOS / Ubuntu / Windows
- [ ] Resolve resolves Cache ≥ 2.1.3

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f71a4-f29d-7136-9681-434d76d4fbc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f71a4-f29d-7136-9681-434d76d4fbc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

