### PR TITLE
Fix: support AppState on WASI

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -35,11 +35,19 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up SwiftWasm
-        id: swiftwasm
-        uses: swiftwasm/setup-swiftwasm@v2
-        with:
-          tag: swift-6.3-DEVELOPMENT-SNAPSHOT-2026-06-11-a
-          target: wasm32-unknown-wasip1
+      - name: Install SwiftWasm SDK
+        env:
+          SWIFTWASM_ASSET: swift-wasm-6.3-SNAPSHOT-2026-06-11-a-wasm32-unknown-wasip1.artifactbundle.zip
+          SWIFTWASM_RELEASE: https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.3-SNAPSHOT-2026-06-11-a
+        run: |
+          apt-get update
+          apt-get install --yes --no-install-recommends ca-certificates curl
+          curl --fail --location --retry 3 --output "/tmp/${SWIFTWASM_ASSET}" \
+            "${SWIFTWASM_RELEASE}/${SWIFTWASM_ASSET}"
+          curl --fail --location --retry 3 --output "/tmp/${SWIFTWASM_ASSET}.sha256" \
+            "${SWIFTWASM_RELEASE}/${SWIFTWASM_ASSET}.sha256"
+          cd /tmp
+          sed "s|$|  ${SWIFTWASM_ASSET}|" "${SWIFTWASM_ASSET}.sha256" | sha256sum --check -
+          swift sdk install "/tmp/${SWIFTWASM_ASSET}"
       - name: Build for WebAssembly
-        run: swift build --swift-sdk "${{ steps.swiftwasm.outputs.swift-sdk-id }}"
+        run: swift build --swift-sdk 6.3-SNAPSHOT-2026-06-11-a-wasm32-unknown-wasip1

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -27,3 +27,19 @@ jobs:
         run: swift test -v
         env:
           APPSTATE_STRICT: "1"
+
+  wasm-build:
+    name: WebAssembly
+    runs-on: ubuntu-latest
+    container: swift:6.3.3-noble
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up SwiftWasm
+        id: swiftwasm
+        uses: swiftwasm/setup-swiftwasm@v2
+        with:
+          tag: swift-6.3-DEVELOPMENT-SNAPSHOT-2026-06-11-a
+          target: wasm32-unknown-wasip1
+      - name: Build for WebAssembly
+        run: swift build --swift-sdk "${{ steps.swiftwasm.outputs.swift-sdk-id }}"

--- a/Sources/AppState/Application/Application+public.swift
+++ b/Sources/AppState/Application/Application+public.swift
@@ -66,7 +66,9 @@ public extension Application {
     static func promote<CustomApplication: Application>(
         to customApplication: CustomApplication.Type
     ) -> CustomApplication.Type {
+        #if !os(WASI)
         NotificationCenter.default.removeObserver(shared)
+        #endif
 
         let cache = shared.cache
         shared = customApplication.init()
@@ -672,7 +674,7 @@ public extension Application {
     }
 }
 
-#if !os(Linux) && !os(Windows)
+#if canImport(Security)
 // MARK: - SyncState Functions
 
 @available(watchOS 9.0, *)

--- a/Sources/AppState/Application/Application.swift
+++ b/Sources/AppState/Application/Application.swift
@@ -100,12 +100,14 @@ open class Application: NSObject {
     ///   delivery would break the synchronous `withObservationTracking` contract that AppState and
     ///   SwiftUI rely on when already on the main thread.
     public func notifyChange() {
+        #if !os(WASI)
         assert(Thread.isMainThread, "Application.notifyChange() must be called on the main thread.")
+        #endif
 
         changeAnchor &+= 1
     }
 
-    #if !os(Linux) && !os(Windows)
+    #if canImport(Security)
     /**
      Called when the value of one or more keys in the local key-value store changed due to incoming data pushed from iCloud.
 

--- a/Sources/AppState/Application/Types/Helper/ApplicationLogger.swift
+++ b/Sources/AppState/Application/Types/Helper/ApplicationLogger.swift
@@ -1,4 +1,4 @@
-#if os(Linux) || os(Windows)
+#if !canImport(OSLog)
 import Foundation
 
 /// `ApplicationLogger` is a struct that provides logging functionalities for Linux and Windows operating systems using closures.

--- a/Sources/AppState/Application/Types/Helper/FileManager+AppState.swift
+++ b/Sources/AppState/Application/Types/Helper/FileManager+AppState.swift
@@ -8,7 +8,7 @@ extension FileManager {
             return "~/App"
         }
 
-        #if !os(Linux) && !os(Windows)
+        #if canImport(Security)
         if #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) {
             return path.appending(path: "App").path()
         } else {
@@ -144,7 +144,7 @@ extension FileManager {
     }
 
     func url(filePath: String) -> URL {
-        #if !os(Linux) && !os(Windows)
+        #if canImport(Security)
         if #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) {
             return URL(filePath: filePath)
         } else {

--- a/Sources/AppState/Application/Types/Helper/UbiquitousKeyValueStoreManaging.swift
+++ b/Sources/AppState/Application/Types/Helper/UbiquitousKeyValueStoreManaging.swift
@@ -1,4 +1,4 @@
-#if !os(Linux) && !os(Windows)
+#if canImport(Security)
 import Foundation
 
 /// A protocol that provides a thread-safe interface for interacting with `NSUbiquitousKeyValueStore`,

--- a/Sources/AppState/Application/Types/State/Application+SecureState.swift
+++ b/Sources/AppState/Application/Types/State/Application+SecureState.swift
@@ -1,4 +1,4 @@
-#if !os(Linux) && !os(Windows)
+#if canImport(Security)
 import Security
 import Foundation
 

--- a/Sources/AppState/Application/Types/State/Application+SyncState.swift
+++ b/Sources/AppState/Application/Types/State/Application+SyncState.swift
@@ -1,4 +1,4 @@
-#if !os(Linux) && !os(Windows)
+#if canImport(Security)
 import Foundation
 
 @available(watchOS 9.0, *)

--- a/Sources/AppState/Dependencies/Keychain.swift
+++ b/Sources/AppState/Dependencies/Keychain.swift
@@ -1,4 +1,4 @@
-#if !os(Linux) && !os(Windows)
+#if canImport(Security)
 import Cache
 import Foundation
 import os

--- a/Sources/AppState/PropertyWrappers/State/SecureState.swift
+++ b/Sources/AppState/PropertyWrappers/State/SecureState.swift
@@ -1,4 +1,4 @@
-#if !os(Linux) && !os(Windows)
+#if canImport(Security)
 import Combine
 import SwiftUI
 

--- a/Sources/AppState/PropertyWrappers/State/SyncState.swift
+++ b/Sources/AppState/PropertyWrappers/State/SyncState.swift
@@ -1,4 +1,4 @@
-#if !os(Linux) && !os(Windows)
+#if canImport(Security)
 import Foundation
 import Combine
 import SwiftUI


### PR DESCRIPTION
## Summary
- guard Apple-only Security and iCloud APIs by module availability
- use WASI-compatible notification and logging paths
- add an actual WebAssembly cross-build to Ubuntu CI

## Root Cause
AppState treated every platform except Linux and Windows as Apple. A WASI build therefore attempted to import Security and use Foundation APIs unavailable in WebAssembly.

## Impact
AppState 3 can now compile as a dependency of SwiftWasm applications while preserving its existing Apple, Linux, and Windows behavior.

## Test Plan
- [x] `fledge run lint` (165 tests, strict warnings)
- [x] `swift build --swift-sdk 6.3-SNAPSHOT-2026-06-11-a-wasm32-unknown-wasip1` in `swift:6.3.3-noble`
- [x] `actionlint .github/workflows/ubuntu.yml`
